### PR TITLE
Migration: complete native finalize, verify, and burn execution

### DIFF
--- a/scripts/token_migration_dry_run.sh
+++ b/scripts/token_migration_dry_run.sh
@@ -12,16 +12,20 @@ WORK_DIR=${MIGRATION_DRY_RUN_DIR:-"$ROOT_DIR/logs/token_migration_dry_run"}
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
 REGISTRY_JSON="$WORK_DIR/stake_registry.json"
-SNAPSHOT_JSON="$WORK_DIR/migration_snapshot.json"
-CLAIMS_JSON="$WORK_DIR/migration_claims.json"
-APPLY_STATE_JSON="$WORK_DIR/migration_apply_state.json"
-MIGRATION_ANCHOR_JSON="$WORK_DIR/migration_anchor.json"
+FINALIZE_DIR="$WORK_DIR/finalize"
+SNAPSHOT_JSON="$FINALIZE_DIR/migration_snapshot.json"
+CLAIMS_JSON="$FINALIZE_DIR/migration_claims.json"
+APPLY_STATE_JSON="$FINALIZE_DIR/migration_apply_state.json"
+MIGRATION_ANCHOR_JSON="$FINALIZE_DIR/migration_anchor.json"
+MIGRATION_ENVELOPE_JSON="$FINALIZE_DIR/migration_anchor_envelope.json"
+BURN_OUTBOX_JSONL="$WORK_DIR/token_burn_outbox.jsonl"
+BURN_STATE_JSON="$WORK_DIR/token_burn_exec_state.json"
 TOKEN_ARTIFACT_JSON="$WORK_DIR/PowerHouseToken.json"
 LEDGER_DIR="$WORK_DIR/ledger"
 ANCHOR_TXT="$WORK_DIR/anchor.txt"
 PROOF_JSON="$WORK_DIR/proof.json"
 
-mkdir -p "$LEDGER_DIR"
+mkdir -p "$LEDGER_DIR" "$FINALIZE_DIR"
 
 cat >"$REGISTRY_JSON" <<'JSON'
 {
@@ -33,55 +37,82 @@ cat >"$REGISTRY_JSON" <<'JSON'
 }
 JSON
 
-echo "[1/9] build + tests"
+echo "[1/11] build + tests"
 "$CARGO_BIN" test
 
-echo "[2/9] deterministic stake snapshot"
+echo "[2/11] run deterministic migration finalize"
 "$CARGO_BIN" run --features net --bin julian --quiet -- \
-  stake snapshot --registry "$REGISTRY_JSON" --height 1 --output "$SNAPSHOT_JSON"
-
-echo "[3/9] deterministic claim manifest + proofs"
-./scripts/build_migration_claims.sh \
-  --snapshot "$SNAPSHOT_JSON" \
-  --output "$CLAIMS_JSON" \
-  --mode native \
-  --amount-source total \
-  --conversion-ratio 1
-
-echo "[4/9] apply native claims to registry"
-"$CARGO_BIN" run --features net --bin julian --quiet -- \
-  stake apply-claims \
+  migration finalize \
     --registry "$REGISTRY_JSON" \
-    --claims "$CLAIMS_JSON" \
-    --state "$APPLY_STATE_JSON"
-
-echo "[5/9] governance migration proposal anchor"
-"$CARGO_BIN" run --features net --bin julian --quiet -- \
-  governance propose-migration \
-    --snapshot-height 1 \
+    --height 1 \
+    --log-dir "$LEDGER_DIR" \
+    --output-dir "$FINALIZE_DIR" \
     --token-contract "native://julian" \
     --conversion-ratio 1 \
     --treasury-mint 0 \
-    --log-dir "$LEDGER_DIR" \
+    --amount-source total \
     --node-id "dry-run" \
     --quorum 1 \
-    --output "$MIGRATION_ANCHOR_JSON"
+    --apply-state "$APPLY_STATE_JSON" \
+    --allow-unfrozen \
+    --force
 
-echo "[6/9] produce baseline ledger anchor + proof"
+echo "[3/11] verify migration state integrity"
+"$CARGO_BIN" run --features net --bin julian --quiet -- \
+  migration verify-state \
+    --registry "$REGISTRY_JSON" \
+    --claims "$CLAIMS_JSON" \
+    --state "$APPLY_STATE_JSON" \
+    --require-complete
+
+echo "[4/11] create synthetic native burn intent"
+cat >"$BURN_OUTBOX_JSONL" <<'JSONL'
+{"schema":"mfenx.powerhouse.token-burn-intent.v1","token_contract":"native://julian","pubkey_b64":"AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=","reason":"dry-run synthetic"}
+JSONL
+
+echo "[5/11] execute native burn intents"
+"$CARGO_BIN" run --features net --bin julian --quiet -- \
+  migration execute-burn-intents \
+    --registry "$REGISTRY_JSON" \
+    --outbox "$BURN_OUTBOX_JSONL" \
+    --state "$BURN_STATE_JSON"
+
+echo "[6/11] verify anchor artifact from finalize"
+python3 - "$MIGRATION_ANCHOR_JSON" "$MIGRATION_ENVELOPE_JSON" <<'PY'
+import json, sys
+doc = json.load(open(sys.argv[1], "r", encoding="utf-8"))
+if "migration_anchor" not in doc:
+    raise SystemExit("missing migration_anchor object in migration artifact")
+anchor = doc.get("anchor_json")
+if not isinstance(anchor, dict):
+    raise SystemExit("missing anchor_json object in migration artifact")
+if "schema" not in anchor:
+    raise SystemExit("anchor_json missing schema")
+json.dump(anchor, open(sys.argv[2], "w", encoding="utf-8"), indent=2)
+PY
+
+echo "[7/11] produce baseline ledger anchor + proof"
 "$CARGO_BIN" run --bin julian --quiet -- node run dry-run "$LEDGER_DIR" "$ANCHOR_TXT"
 "$CARGO_BIN" run --bin julian --quiet -- node prove "$LEDGER_DIR" 0 0 "$PROOF_JSON"
 
-echo "[7/9] verify anchor proof"
+echo "[8/11] verify anchor proof"
 "$CARGO_BIN" run --bin julian --quiet -- node verify-proof "$ANCHOR_TXT" "$PROOF_JSON"
 
-echo "[8/9] optional token artifact build (RUN_TOKEN_BUILD=1)"
+echo "[9/11] check idempotent burn executor"
+"$CARGO_BIN" run --features net --bin julian --quiet -- \
+  migration execute-burn-intents \
+    --registry "$REGISTRY_JSON" \
+    --outbox "$BURN_OUTBOX_JSONL" \
+    --state "$BURN_STATE_JSON"
+
+echo "[10/11] optional token artifact build (RUN_TOKEN_BUILD=1)"
 if [[ "$RUN_TOKEN_BUILD" == "1" ]]; then
   OUT_FILE="$TOKEN_ARTIFACT_JSON" ./scripts/build_powerhouse_token_artifact.sh
 else
   echo "RUN_TOKEN_BUILD=0, skipping solidity compile"
 fi
 
-echo "[9/9] optional smoke net (--with-migration)"
+echo "[11/11] optional smoke net (--with-migration)"
 if [[ "$RUN_NET_SMOKE" == "1" ]]; then
   ./scripts/smoke_net.sh --with-migration
 else
@@ -93,7 +124,10 @@ echo "artifacts:"
 echo "  snapshot: $SNAPSHOT_JSON"
 echo "  claims: $CLAIMS_JSON"
 echo "  apply_state: $APPLY_STATE_JSON"
+echo "  burn_outbox: $BURN_OUTBOX_JSONL"
+echo "  burn_state: $BURN_STATE_JSON"
 echo "  migration_anchor: $MIGRATION_ANCHOR_JSON"
+echo "  migration_envelope: $MIGRATION_ENVELOPE_JSON"
 if [[ "$RUN_TOKEN_BUILD" == "1" ]]; then
   echo "  token_artifact: $TOKEN_ARTIFACT_JSON"
 fi

--- a/scripts/verify_migration_contract.sh
+++ b/scripts/verify_migration_contract.sh
@@ -18,27 +18,41 @@ check_contains() {
   fi
 }
 
-echo "[1/10] verify migration structs"
-rg -q "pub struct MigrationProposal" src/net/governance.rs || fail "MigrationProposal missing"
-rg -q "pub snapshot_height: u64" src/net/governance.rs || fail "MigrationProposal.snapshot_height missing"
-rg -q "pub token_contract: String" src/net/governance.rs || fail "MigrationProposal.token_contract missing"
-rg -q "pub conversion_ratio: u64" src/net/governance.rs || fail "MigrationProposal.conversion_ratio missing"
-rg -q "pub treasury_mint: u64" src/net/governance.rs || fail "MigrationProposal.treasury_mint missing"
+search_q() {
+  local pattern="$1"
+  shift
+  if command -v rg >/dev/null 2>&1; then
+    rg -q "$pattern" "$@"
+  else
+    grep -q "$pattern" "$@"
+  fi
+}
 
-echo "[2/10] verify deterministic snapshot + claims commands"
-rg -q "fn run_snapshot" src/commands/stake_snapshot.rs || fail "run_snapshot missing"
-rg -q "fn run_build_claims" src/commands/migration_claims.rs || fail "run_build_claims missing"
-rg -q "stake snapshot" src/bin/julian.rs || fail "stake snapshot CLI wiring missing"
-rg -q "stake claims" src/bin/julian.rs || fail "stake claims CLI wiring missing"
+echo "[1/12] verify migration structs"
+search_q "pub struct MigrationProposal" src/net/governance.rs || fail "MigrationProposal missing"
+search_q "pub snapshot_height: u64" src/net/governance.rs || fail "MigrationProposal.snapshot_height missing"
+search_q "pub token_contract: String" src/net/governance.rs || fail "MigrationProposal.token_contract missing"
+search_q "pub conversion_ratio: u64" src/net/governance.rs || fail "MigrationProposal.conversion_ratio missing"
+search_q "pub treasury_mint: u64" src/net/governance.rs || fail "MigrationProposal.treasury_mint missing"
 
-echo "[3/10] verify freeze hooks"
-rg -q "PH_MIGRATION_MODE" src/net/migration.rs || fail "PH_MIGRATION_MODE hook missing"
-rg -q "migration freeze active: stake bonding is disabled" src/bin/julian.rs || fail "stake freeze check missing"
-rg -q "migration freeze active: blob ingestion disabled" src/net/swarm.rs || fail "blob freeze check missing"
+echo "[2/12] verify deterministic snapshot + claims commands"
+search_q "fn run_snapshot" src/commands/stake_snapshot.rs || fail "run_snapshot missing"
+search_q "fn run_build_claims" src/commands/migration_claims.rs || fail "run_build_claims missing"
+search_q "fn run_apply_claims" src/commands/migration_apply_claims.rs || fail "run_apply_claims missing"
+search_q "fn run_finalize_migration" src/commands/migration_finalize.rs || fail "run_finalize_migration missing"
+search_q "fn run_execute_burn_intents" src/commands/migration_burn_executor.rs || fail "run_execute_burn_intents missing"
+search_q "stake snapshot" src/bin/julian.rs || fail "stake snapshot CLI wiring missing"
+search_q "stake claims" src/bin/julian.rs || fail "stake claims CLI wiring missing"
+search_q "migration finalize" src/bin/julian.rs || fail "migration finalize CLI wiring missing"
 
-echo "[4/10] verify help surfaces"
+echo "[3/12] verify freeze hooks"
+search_q "PH_MIGRATION_MODE" src/net/migration.rs || fail "PH_MIGRATION_MODE hook missing"
+search_q "migration freeze active: stake bonding is disabled" src/bin/julian.rs || fail "stake freeze check missing"
+search_q "migration freeze active: blob ingestion disabled" src/net/swarm.rs || fail "blob freeze check missing"
+
+echo "[4/12] verify help surfaces"
 stake_help="$(cargo run --features net --bin julian --quiet -- stake --help 2>&1 || true)"
-check_contains "$stake_help" "Usage: julian stake <show|fund|bond|snapshot|claims|unbond|reward>" "stake help"
+check_contains "$stake_help" "Usage: julian stake <show|fund|bond|snapshot|claims|apply-claims|unbond|reward>" "stake help"
 
 gov_help="$(cargo run --features net --bin julian --quiet -- governance --help 2>&1 || true)"
 check_contains "$gov_help" "Usage: julian governance <propose-migration>" "governance help"
@@ -46,7 +60,10 @@ check_contains "$gov_help" "Usage: julian governance <propose-migration>" "gover
 net_help="$(cargo run --features net --bin julian --quiet -- net --help 2>&1 || true)"
 check_contains "$net_help" "Usage: julian net <start|anchor|verify-envelope>" "net help"
 
-echo "[5/10] verify migration command help"
+migration_help="$(cargo run --features net --bin julian --quiet -- migration --help 2>&1 || true)"
+check_contains "$migration_help" "Usage: julian migration <finalize|verify-state|execute-burn-intents>" "migration help"
+
+echo "[5/12] verify migration command help"
 snap_help="$(cargo run --features net --bin julian --quiet -- stake snapshot --help 2>&1 || true)"
 check_contains "$snap_help" "Usage: julian stake snapshot" "stake snapshot help"
 
@@ -56,7 +73,10 @@ check_contains "$claims_help" "Usage: julian stake claims" "stake claims help"
 proposal_help="$(cargo run --features net --bin julian --quiet -- governance propose-migration --help 2>&1 || true)"
 check_contains "$proposal_help" "Usage: julian governance propose-migration" "governance propose-migration help"
 
-echo "[6/10] verify net anchor compatibility"
+finalize_help="$(cargo run --features net --bin julian --quiet -- migration finalize --help 2>&1 || true)"
+check_contains "$finalize_help" "Usage: julian migration <finalize|verify-state|execute-burn-intents>" "migration finalize help"
+
+echo "[6/12] verify net anchor compatibility"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 mkdir -p "$TMP_DIR/logs"
@@ -67,15 +87,18 @@ check_contains "$anchor_flagged" "\"schema\"" "net anchor --log-dir output"
 anchor_positional="$(cargo run --features net --bin julian --quiet -- net anchor "$TMP_DIR/logs" 2>&1 || true)"
 check_contains "$anchor_positional" "\"schema\"" "net anchor positional output"
 
-echo "[7/10] verify token mode flags exposed"
+echo "[7/12] verify token mode flags exposed"
 net_start_help="$(cargo run --features net --bin julian --quiet -- net start --help 2>&1 || true)"
 check_contains "$net_start_help" "--token-mode" "net start token-mode flag"
 check_contains "$net_start_help" "--token-oracle" "net start token-oracle flag"
 
-echo "[8/10] verify claim manifest generation works"
+echo "[8/12] verify claim manifest generation works"
 REGISTRY="$TMP_DIR/registry.json"
 SNAPSHOT="$TMP_DIR/snapshot.json"
 CLAIMS="$TMP_DIR/claims.json"
+STATE="$TMP_DIR/apply_state.json"
+BURN_OUTBOX="$TMP_DIR/token_burn_outbox.jsonl"
+BURN_STATE="$TMP_DIR/token_burn_exec_state.json"
 cat >"$REGISTRY" <<'JSON'
 {
   "accounts": {
@@ -90,6 +113,8 @@ cargo run --features net --bin julian --quiet -- \
   stake snapshot --registry "$REGISTRY" --height 7 --output "$SNAPSHOT" >/dev/null
 cargo run --features net --bin julian --quiet -- \
   stake claims --snapshot "$SNAPSHOT" --output "$CLAIMS" --amount-source total >/dev/null
+cargo run --features net --bin julian --quiet -- \
+  stake apply-claims --registry "$REGISTRY" --claims "$CLAIMS" --state "$STATE" >/dev/null
 
 claims_root="$(python3 - "$CLAIMS" <<'PY'
 import json, sys
@@ -101,12 +126,24 @@ PY
 )"
 check_contains "$claims_root" "0x" "claim manifest root"
 
-echo "[9/10] verify phase-3 scripts are present"
+echo "[9/12] verify verify-state command"
+cargo run --features net --bin julian --quiet -- \
+  migration verify-state --registry "$REGISTRY" --claims "$CLAIMS" --state "$STATE" --require-complete >/dev/null
+
+echo "[10/12] verify native burn executor"
+cat >"$BURN_OUTBOX" <<'JSONL'
+{"schema":"mfenx.powerhouse.token-burn-intent.v1","token_contract":"native://julian","pubkey_b64":"AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=","reason":"verify script"}
+JSONL
+cargo run --features net --bin julian --quiet -- \
+  migration execute-burn-intents --registry "$REGISTRY" --outbox "$BURN_OUTBOX" --state "$BURN_STATE" >/dev/null
+
+echo "[11/12] verify migration scripts are present"
 [[ -x scripts/build_migration_claims.sh ]] || fail "scripts/build_migration_claims.sh missing"
 [[ -x scripts/build_powerhouse_token_artifact.sh ]] || fail "scripts/build_powerhouse_token_artifact.sh missing"
 [[ -x scripts/deploy_powerhouse_token.py ]] || fail "scripts/deploy_powerhouse_token.py missing"
+[[ -x scripts/token_migration_dry_run.sh ]] || fail "scripts/token_migration_dry_run.sh missing"
 
-echo "[10/10] verify deploy script help"
+echo "[12/12] verify deploy script help"
 deploy_help="$(python3 scripts/deploy_powerhouse_token.py --help 2>&1 || true)"
 check_contains "$deploy_help" "--migration-root" "deploy script options"
 

--- a/src/commands/migration_burn_executor.rs
+++ b/src/commands/migration_burn_executor.rs
@@ -1,0 +1,259 @@
+#![cfg(feature = "net")]
+
+use crate::net::StakeRegistry;
+use blake2::digest::{consts::U32, Digest};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+type Blake2b256 = blake2::Blake2b<U32>;
+
+const EXEC_STATE_SCHEMA: &str = "mfenx.powerhouse.migration-burn-exec-state.v1";
+
+/// Options for executing migration burn intents.
+#[derive(Debug, Clone)]
+pub struct ExecuteBurnOptions {
+    /// Optional path to outbox state file.
+    pub state_path: Option<String>,
+    /// Dry-run mode computes actions without writing registry/state changes.
+    pub dry_run: bool,
+}
+
+/// Summary returned after executing burn intents.
+#[derive(Debug, Clone)]
+pub struct ExecuteBurnSummary {
+    /// Number of outbox records processed in this run.
+    pub processed: usize,
+    /// Number of records skipped because they were already processed.
+    pub skipped: usize,
+    /// Number of native intents executed as slashes.
+    pub native_executed: usize,
+    /// Number of non-native intents left untouched.
+    pub unsupported_mode: usize,
+    /// State file path used for idempotency.
+    pub state_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BurnIntent {
+    #[serde(default)]
+    schema: String,
+    token_contract: Option<String>,
+    pubkey_b64: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct ExecuteState {
+    schema: String,
+    updated_at_ms: u64,
+    processed_ids: Vec<String>,
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn token_mode_is_native(mode: &str) -> bool {
+    let trimmed = mode.trim();
+    trimmed.eq_ignore_ascii_case("native") || trimmed.to_ascii_lowercase().starts_with("native://")
+}
+
+fn resolve_state_path(outbox_path: &Path, explicit: Option<&str>) -> PathBuf {
+    if let Some(path) = explicit {
+        return PathBuf::from(path);
+    }
+    outbox_path.with_file_name("token_burn_exec_state.json")
+}
+
+fn intent_id(raw_line: &str) -> String {
+    let mut hasher = Blake2b256::new();
+    hasher.update(b"mfenx-migration-burn-intent-id-v1");
+    hasher.update(raw_line.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn load_state(path: &Path) -> Result<ExecuteState, String> {
+    if !path.exists() {
+        return Ok(ExecuteState {
+            schema: EXEC_STATE_SCHEMA.to_string(),
+            updated_at_ms: now_millis(),
+            processed_ids: Vec::new(),
+        });
+    }
+    let bytes = std::fs::read(path)
+        .map_err(|err| format!("failed to read burn state {}: {err}", path.display()))?;
+    let mut state: ExecuteState = serde_json::from_slice(&bytes)
+        .map_err(|err| format!("invalid burn state {}: {err}", path.display()))?;
+    if state.schema.trim().is_empty() {
+        state.schema = EXEC_STATE_SCHEMA.to_string();
+    }
+    Ok(state)
+}
+
+fn save_state(path: &Path, state: &ExecuteState) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
+    }
+    let encoded = serde_json::to_vec_pretty(state)
+        .map_err(|err| format!("failed to encode burn state: {err}"))?;
+    std::fs::write(path, encoded)
+        .map_err(|err| format!("failed to write burn state {}: {err}", path.display()))
+}
+
+/// Execute native burn intents by slashing corresponding stake registry accounts.
+///
+/// Intents are consumed idempotently using a persistent state file.
+pub fn run_execute_burn_intents(
+    registry_path: &str,
+    outbox_path: &str,
+    opts: &ExecuteBurnOptions,
+) -> Result<ExecuteBurnSummary, String> {
+    let registry_path = Path::new(registry_path);
+    let outbox_path = Path::new(outbox_path);
+    let state_path = resolve_state_path(outbox_path, opts.state_path.as_deref());
+
+    let outbox = if outbox_path.exists() {
+        std::fs::read_to_string(outbox_path)
+            .map_err(|err| format!("failed to read outbox {}: {err}", outbox_path.display()))?
+    } else {
+        String::new()
+    };
+
+    let mut state = load_state(&state_path)?;
+    let mut seen = state
+        .processed_ids
+        .iter()
+        .cloned()
+        .collect::<HashSet<String>>();
+
+    let mut registry = StakeRegistry::load(registry_path)
+        .map_err(|err| format!("failed to load registry {}: {err}", registry_path.display()))?;
+
+    let mut processed = 0usize;
+    let mut skipped = 0usize;
+    let mut native_executed = 0usize;
+    let mut unsupported_mode = 0usize;
+
+    for raw in outbox.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let id = intent_id(line);
+        if !seen.insert(id) {
+            skipped += 1;
+            continue;
+        }
+
+        let intent: BurnIntent = serde_json::from_str(line)
+            .map_err(|err| format!("invalid burn intent record: {err}"))?;
+
+        if !intent.schema.is_empty() && intent.schema != "mfenx.powerhouse.token-burn-intent.v1" {
+            return Err(format!("unexpected burn intent schema: {}", intent.schema));
+        }
+
+        let mode = intent.token_contract.unwrap_or_default();
+        if !token_mode_is_native(&mode) {
+            unsupported_mode += 1;
+            processed += 1;
+            continue;
+        }
+
+        let pk = intent
+            .pubkey_b64
+            .ok_or_else(|| "burn intent missing pubkey_b64".to_string())?;
+        registry.slash(&pk);
+        native_executed += 1;
+        processed += 1;
+    }
+
+    if !opts.dry_run {
+        registry
+            .save(registry_path)
+            .map_err(|err| format!("failed to save registry {}: {err}", registry_path.display()))?;
+        let mut processed_ids = seen.into_iter().collect::<Vec<_>>();
+        processed_ids.sort();
+        state.schema = EXEC_STATE_SCHEMA.to_string();
+        state.updated_at_ms = now_millis();
+        state.processed_ids = processed_ids;
+        save_state(&state_path, &state)?;
+    }
+
+    Ok(ExecuteBurnSummary {
+        processed,
+        skipped,
+        native_executed,
+        unsupported_mode,
+        state_path: state_path.display().to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_execute_burn_intents, ExecuteBurnOptions};
+    use crate::net::StakeRegistry;
+    use serde_json::json;
+    use std::fs;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        p.push(format!("{name}_{ts}"));
+        p
+    }
+
+    #[test]
+    fn execute_native_burn_intents_is_idempotent() {
+        let registry = temp_path("burn_registry.json");
+        let outbox = temp_path("burn_outbox.jsonl");
+        let state = temp_path("burn_state.json");
+
+        let registry_payload = json!({
+            "accounts": {
+                "pk1": {"balance": 10, "stake": 99, "slashed": false}
+            }
+        });
+        fs::write(&registry, serde_json::to_vec(&registry_payload).unwrap()).unwrap();
+
+        let line = json!({
+            "schema":"mfenx.powerhouse.token-burn-intent.v1",
+            "token_contract":"native://julian",
+            "pubkey_b64":"pk1",
+            "reason":"test"
+        })
+        .to_string();
+        fs::write(&outbox, format!("{line}\n")).unwrap();
+
+        let opts = ExecuteBurnOptions {
+            state_path: Some(state.display().to_string()),
+            dry_run: false,
+        };
+
+        let first =
+            run_execute_burn_intents(registry.to_str().unwrap(), outbox.to_str().unwrap(), &opts)
+                .unwrap();
+        assert_eq!(first.native_executed, 1);
+
+        let reg = StakeRegistry::load(&registry).unwrap();
+        assert_eq!(reg.account("pk1").unwrap().stake, 0);
+        assert!(reg.account("pk1").unwrap().slashed);
+
+        let second =
+            run_execute_burn_intents(registry.to_str().unwrap(), outbox.to_str().unwrap(), &opts)
+                .unwrap();
+        assert_eq!(second.skipped, 1);
+
+        let _ = fs::remove_file(registry);
+        let _ = fs::remove_file(outbox);
+        let _ = fs::remove_file(state);
+    }
+}

--- a/src/commands/migration_finalize.rs
+++ b/src/commands/migration_finalize.rs
@@ -1,0 +1,163 @@
+#![cfg(feature = "net")]
+
+use crate::commands::migration_apply_claims::{run_apply_claims, ApplyClaimsOptions};
+use crate::commands::migration_claims::{run_build_claims, BuildClaimsOptions};
+use crate::commands::migration_proposal::{run_propose_migration, ProposeMigrationOptions};
+use crate::commands::stake_snapshot::run_snapshot;
+
+/// Options for running a deterministic end-to-end migration finalize flow.
+#[derive(Debug, Clone)]
+pub struct FinalizeMigrationOptions {
+    /// Path to stake registry JSON.
+    pub registry_path: String,
+    /// Snapshot height for migration cutover.
+    pub snapshot_height: u64,
+    /// Ledger log directory for proposal anchoring.
+    pub log_dir: String,
+    /// Output directory for migration artifacts.
+    pub output_dir: String,
+    /// Token identifier embedded in migration proposal.
+    pub token_contract: String,
+    /// Stake-to-token conversion ratio.
+    pub conversion_ratio: u64,
+    /// Treasury mint amount for proposal metadata.
+    pub treasury_mint: u64,
+    /// Amount source for claims (`stake|balance|total`).
+    pub amount_source: String,
+    /// Include slashed accounts in claims.
+    pub include_slashed: bool,
+    /// Claim-ID salt for deterministic claim generation.
+    pub claim_id_salt: String,
+    /// Node ID embedded in proposal anchor.
+    pub node_id: String,
+    /// Quorum embedded in proposal anchor.
+    pub quorum: usize,
+    /// Optional explicit apply-state path.
+    pub apply_state_path: Option<String>,
+    /// Allow finalize execution when migration freeze is not enabled.
+    pub allow_unfrozen: bool,
+    /// Permit overwriting existing artifacts.
+    pub force: bool,
+}
+
+/// Summary produced by finalize migration workflow.
+#[derive(Debug, Clone)]
+pub struct FinalizeMigrationSummary {
+    /// Snapshot root hex.
+    pub snapshot_root: String,
+    /// Claims merkle root hex.
+    pub claims_root: String,
+    /// Number of claims newly applied.
+    pub applied_claims: usize,
+    /// Number of already-applied claims skipped.
+    pub skipped_claims: usize,
+    /// Snapshot artifact path.
+    pub snapshot_path: String,
+    /// Claims artifact path.
+    pub claims_path: String,
+    /// Apply-state path.
+    pub apply_state_path: String,
+    /// Migration proposal artifact path.
+    pub proposal_path: String,
+}
+
+fn ensure_writable(path: &std::path::Path, force: bool) -> Result<(), String> {
+    if path.exists() && !force {
+        return Err(format!(
+            "{} already exists; rerun with --force to overwrite",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Run full migration finalize pipeline:
+/// freeze-check, snapshot, claims, apply-claims, and proposal anchor artifact.
+pub fn run_finalize_migration(
+    opts: &FinalizeMigrationOptions,
+) -> Result<FinalizeMigrationSummary, String> {
+    crate::net::refresh_migration_mode_from_env();
+    if !opts.allow_unfrozen && !crate::net::migration_mode_frozen() {
+        return Err(
+            "migration freeze is not active (set PH_MIGRATION_MODE=freeze or use --allow-unfrozen)"
+                .to_string(),
+        );
+    }
+
+    let out_dir = std::path::Path::new(&opts.output_dir);
+    std::fs::create_dir_all(out_dir)
+        .map_err(|err| format!("failed to create output dir {}: {err}", out_dir.display()))?;
+
+    let snapshot_path = out_dir.join("migration_snapshot.json");
+    let claims_path = out_dir.join("migration_claims.json");
+    let proposal_path = out_dir.join("migration_anchor.json");
+    let apply_state_path = opts.apply_state_path.clone().unwrap_or_else(|| {
+        out_dir
+            .join("migration_apply_state.json")
+            .display()
+            .to_string()
+    });
+
+    ensure_writable(&snapshot_path, opts.force)?;
+    ensure_writable(&claims_path, opts.force)?;
+    ensure_writable(&proposal_path, opts.force)?;
+
+    let snapshot_root = run_snapshot(
+        &opts.registry_path,
+        opts.snapshot_height,
+        snapshot_path.to_str().unwrap_or("migration_snapshot.json"),
+    )?;
+
+    let claims_root = run_build_claims(
+        snapshot_path.to_str().unwrap_or("migration_snapshot.json"),
+        claims_path.to_str().unwrap_or("migration_claims.json"),
+        &BuildClaimsOptions {
+            amount_source: opts.amount_source.clone(),
+            include_slashed: opts.include_slashed,
+            conversion_ratio: if opts.conversion_ratio == 0 {
+                1
+            } else {
+                opts.conversion_ratio
+            },
+            claim_id_salt: opts.claim_id_salt.clone(),
+            token_contract: Some(opts.token_contract.clone()),
+            snapshot_height_override: Some(opts.snapshot_height),
+            claim_mode: "native".to_string(),
+        },
+    )?;
+
+    let apply_summary = run_apply_claims(
+        &opts.registry_path,
+        claims_path.to_str().unwrap_or("migration_claims.json"),
+        &ApplyClaimsOptions {
+            state_path: Some(apply_state_path.clone()),
+            dry_run: false,
+        },
+    )?;
+
+    run_propose_migration(&ProposeMigrationOptions {
+        snapshot_height: opts.snapshot_height,
+        token_contract: opts.token_contract.clone(),
+        conversion_ratio: if opts.conversion_ratio == 0 {
+            1
+        } else {
+            opts.conversion_ratio
+        },
+        treasury_mint: opts.treasury_mint,
+        log_dir: opts.log_dir.clone(),
+        node_id: opts.node_id.clone(),
+        quorum: opts.quorum,
+        output: Some(proposal_path.display().to_string()),
+    })?;
+
+    Ok(FinalizeMigrationSummary {
+        snapshot_root,
+        claims_root,
+        applied_claims: apply_summary.applied,
+        skipped_claims: apply_summary.skipped,
+        snapshot_path: snapshot_path.display().to_string(),
+        claims_path: claims_path.display().to_string(),
+        apply_state_path,
+        proposal_path: proposal_path.display().to_string(),
+    })
+}

--- a/src/commands/migration_proposal.rs
+++ b/src/commands/migration_proposal.rs
@@ -1,0 +1,213 @@
+#![cfg(feature = "net")]
+
+use crate::net::{AnchorJson, MigrationAnchor, MigrationProposal};
+use crate::{
+    compute_fold_digest, julian_genesis_anchor, parse_log_file, read_fold_digest_hint, EntryAnchor,
+    LedgerAnchor,
+};
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Parameters for generating a migration proposal artifact.
+#[derive(Debug, Clone)]
+pub struct ProposeMigrationOptions {
+    /// Snapshot height selected for migration cutover.
+    pub snapshot_height: u64,
+    /// Token identifier (for example `native://julian`).
+    pub token_contract: String,
+    /// Stake-to-token conversion ratio.
+    pub conversion_ratio: u64,
+    /// Treasury mint amount applied at cutover.
+    pub treasury_mint: u64,
+    /// Log directory used to build an anchor context.
+    pub log_dir: String,
+    /// Node ID embedded in generated anchor JSON.
+    pub node_id: String,
+    /// Quorum threshold embedded in generated anchor JSON.
+    pub quorum: usize,
+    /// Optional output path for the encoded artifact.
+    pub output: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct MigrationProposalArtifact {
+    migration_anchor: MigrationAnchor,
+    anchor_json: AnchorJson,
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn is_ledger_file(path: &Path) -> bool {
+    match path.file_name().and_then(|n| n.to_str()) {
+        Some(name) => name.starts_with("ledger_") && name.ends_with(".txt"),
+        None => false,
+    }
+}
+
+fn load_anchor_from_logs(path: &Path) -> Result<LedgerAnchor, String> {
+    let mut cutoff: Option<String> = None;
+    let mut anchor_from_checkpoint = false;
+    let anchor = match crate::net::load_latest_checkpoint(path) {
+        Ok(Some(checkpoint)) => {
+            anchor_from_checkpoint = true;
+            match checkpoint.into_ledger() {
+                Ok((anchor, cp_cutoff)) => {
+                    cutoff = cp_cutoff;
+                    anchor
+                }
+                Err(err) => return Err(format!("checkpoint error: {err}")),
+            }
+        }
+        Ok(None) => julian_genesis_anchor(),
+        Err(err) => return Err(format!("checkpoint error: {err}")),
+    };
+
+    let mut entries = anchor.entries;
+    let mut metadata = anchor.metadata;
+    if !anchor_from_checkpoint {
+        metadata.challenge_mode = None;
+        metadata.fold_digest = None;
+    }
+    metadata
+        .crate_version
+        .get_or_insert_with(|| env!("CARGO_PKG_VERSION").to_string());
+
+    let mut files: Vec<PathBuf> = fs::read_dir(path)
+        .map_err(|err| format!("failed to read directory {}: {err}", path.display()))?
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|p| p.is_file() && is_ledger_file(p))
+        .collect();
+    files.sort();
+
+    for file in files {
+        if let Some(ref cutoff_name) = cutoff {
+            if let Some(name) = file.file_name().and_then(|n| n.to_str()) {
+                if name <= cutoff_name.as_str() {
+                    continue;
+                }
+            }
+        }
+
+        let parsed = parse_log_file(&file)?;
+        if let Some(mode) = parsed.metadata.challenge_mode {
+            match &mut metadata.challenge_mode {
+                None => metadata.challenge_mode = Some(mode),
+                Some(existing) if existing != &mode => {
+                    return Err(format!(
+                        "{} challenge_mode {} conflicts with existing {}",
+                        file.display(),
+                        mode,
+                        existing
+                    ));
+                }
+                _ => {}
+            }
+        }
+        if let Some(digest) = parsed.metadata.fold_digest {
+            if let Some(existing) = &metadata.fold_digest {
+                if existing != &digest && anchor_from_checkpoint {
+                    return Err(format!(
+                        "{} fold_digest conflicts with existing value",
+                        file.display()
+                    ));
+                }
+            }
+            metadata.fold_digest = Some(digest);
+        }
+
+        let entry_hashes = vec![parsed.digest];
+        entries.push(EntryAnchor {
+            statement: parsed.statement,
+            merkle_root: crate::merkle_root(&entry_hashes),
+            hashes: entry_hashes,
+        });
+    }
+
+    if entries.is_empty() {
+        entries = julian_genesis_anchor().entries;
+    }
+
+    if let Some(digest) = read_fold_digest_hint(path)? {
+        if let Some(existing) = &metadata.fold_digest {
+            if existing != &digest && anchor_from_checkpoint {
+                return Err("fold_digest hint conflicts with checkpoint metadata".to_string());
+            }
+        }
+        metadata.fold_digest = Some(digest);
+    }
+
+    let mut anchor = LedgerAnchor { entries, metadata };
+    if anchor.metadata.fold_digest.is_none() {
+        anchor.metadata.fold_digest = Some(compute_fold_digest(&anchor));
+    }
+    Ok(anchor)
+}
+
+/// Build and optionally persist a migration proposal artifact.
+///
+/// Returns the encoded JSON artifact payload.
+pub fn run_propose_migration(opts: &ProposeMigrationOptions) -> Result<String, String> {
+    let proposal = MigrationProposal {
+        snapshot_height: opts.snapshot_height,
+        token_contract: opts.token_contract.clone(),
+        conversion_ratio: if opts.conversion_ratio == 0 {
+            1
+        } else {
+            opts.conversion_ratio
+        },
+        treasury_mint: opts.treasury_mint,
+    };
+
+    let migration_anchor = proposal
+        .to_anchor_payload()
+        .map_err(|err| format!("failed to build migration payload: {err}"))?;
+    let proposal_digest = crate::transcript_digest_from_hex(&migration_anchor.proposal_hash)
+        .map_err(|err| format!("invalid proposal hash: {err}"))?;
+
+    let mut ledger = load_anchor_from_logs(Path::new(&opts.log_dir))?;
+    ledger.entries.push(EntryAnchor {
+        statement: migration_anchor.statement.clone(),
+        merkle_root: crate::merkle_root(&[proposal_digest]),
+        hashes: vec![proposal_digest],
+    });
+    ledger.metadata.fold_digest = Some(compute_fold_digest(&ledger));
+    ledger
+        .metadata
+        .crate_version
+        .get_or_insert_with(|| env!("CARGO_PKG_VERSION").to_string());
+
+    let anchor_json = AnchorJson::from_ledger(
+        opts.node_id.clone(),
+        opts.quorum,
+        &ledger,
+        now_millis(),
+        Vec::new(),
+        None,
+    )
+    .map_err(|err| format!("anchor conversion failed: {err}"))?;
+
+    let artifact = MigrationProposalArtifact {
+        migration_anchor,
+        anchor_json,
+    };
+    let encoded = serde_json::to_string_pretty(&artifact)
+        .map_err(|err| format!("failed to encode migration proposal artifact: {err}"))?;
+
+    if let Some(path) = &opts.output {
+        let path_obj = Path::new(path);
+        if let Some(parent) = path_obj.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        fs::write(path_obj, &encoded)
+            .map_err(|err| format!("failed to write {}: {err}", path_obj.display()))?;
+    }
+
+    Ok(encoded)
+}

--- a/src/commands/migration_verify_state.rs
+++ b/src/commands/migration_verify_state.rs
@@ -1,0 +1,258 @@
+#![cfg(feature = "net")]
+
+use crate::net::StakeRegistry;
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+/// Options for validating native migration claims/state consistency.
+#[derive(Debug, Clone)]
+pub struct VerifyStateOptions {
+    /// Require all claims in the artifact to appear in apply-state.
+    pub require_complete: bool,
+    /// Require registry balances to be at least minted totals per account.
+    pub enforce_balance_floor: bool,
+}
+
+/// Verification result summary for migration state.
+#[derive(Debug, Clone)]
+pub struct VerifyStateSummary {
+    /// Total claims in artifact.
+    pub claim_count: usize,
+    /// Applied claims discovered in state file.
+    pub applied_count: usize,
+    /// Claim IDs present in artifact but missing from state.
+    pub missing_count: usize,
+    /// Claim IDs present in state but not in artifact.
+    pub unknown_count: usize,
+    /// Total minted amount represented by applied claims.
+    pub applied_total_mint: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaimsArtifact {
+    claim_mode: String,
+    claims: Vec<ClaimEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaimEntry {
+    pubkey_b64: String,
+    account: String,
+    claim_id: String,
+    mint_amount: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplyState {
+    applied_claim_ids: Vec<String>,
+}
+
+/// Verify migration claims/state consistency and optional registry balance floors.
+pub fn run_verify_state(
+    registry_path: &str,
+    claims_path: &str,
+    state_path: &str,
+    opts: &VerifyStateOptions,
+) -> Result<VerifyStateSummary, String> {
+    let claims_bytes = std::fs::read(Path::new(claims_path))
+        .map_err(|err| format!("failed to read claims {claims_path}: {err}"))?;
+    let claims: ClaimsArtifact = serde_json::from_slice(&claims_bytes)
+        .map_err(|err| format!("invalid claims artifact {claims_path}: {err}"))?;
+
+    if !claims.claim_mode.eq_ignore_ascii_case("native") {
+        return Err(format!(
+            "verify-state supports native claims only (found '{}')",
+            claims.claim_mode
+        ));
+    }
+
+    let state_bytes = std::fs::read(Path::new(state_path))
+        .map_err(|err| format!("failed to read apply state {state_path}: {err}"))?;
+    let state: ApplyState = serde_json::from_slice(&state_bytes)
+        .map_err(|err| format!("invalid apply state {state_path}: {err}"))?;
+
+    let registry = StakeRegistry::load(Path::new(registry_path))
+        .map_err(|err| format!("failed to load registry {registry_path}: {err}"))?;
+
+    let mut by_id: HashMap<String, (String, u128)> = HashMap::new();
+    for claim in &claims.claims {
+        if claim.account != claim.pubkey_b64 {
+            return Err(format!(
+                "native claim account mismatch for claim {} (account='{}', pubkey='{}')",
+                claim.claim_id, claim.account, claim.pubkey_b64
+            ));
+        }
+        if by_id.contains_key(&claim.claim_id) {
+            return Err(format!(
+                "duplicate claim_id in claims artifact: {}",
+                claim.claim_id
+            ));
+        }
+        let mint = claim
+            .mint_amount
+            .parse::<u128>()
+            .map_err(|err| format!("invalid mint_amount for claim {}: {err}", claim.claim_id))?;
+        by_id.insert(claim.claim_id.clone(), (claim.pubkey_b64.clone(), mint));
+    }
+
+    let mut seen_state = HashSet::new();
+    let mut unknown_count = 0usize;
+    let mut applied_count = 0usize;
+    let mut applied_total_mint: u128 = 0;
+    let mut minted_by_pk: HashMap<String, u128> = HashMap::new();
+
+    for claim_id in state.applied_claim_ids {
+        if !seen_state.insert(claim_id.clone()) {
+            continue;
+        }
+        if let Some((pk, mint)) = by_id.get(&claim_id) {
+            applied_count += 1;
+            applied_total_mint = applied_total_mint.saturating_add(*mint);
+            let entry = minted_by_pk.entry(pk.clone()).or_insert(0);
+            *entry = entry.saturating_add(*mint);
+        } else {
+            unknown_count += 1;
+        }
+    }
+
+    let claim_count = by_id.len();
+    let missing_count = claim_count.saturating_sub(applied_count);
+
+    if opts.require_complete && missing_count > 0 {
+        return Err(format!(
+            "migration apply state incomplete: {missing_count} claim(s) missing"
+        ));
+    }
+
+    if unknown_count > 0 {
+        return Err(format!(
+            "migration apply state contains {unknown_count} unknown claim id(s)"
+        ));
+    }
+
+    if opts.enforce_balance_floor {
+        for (pk, minted) in minted_by_pk {
+            if minted > u64::MAX as u128 {
+                return Err(format!("minted amount overflow for account {pk}"));
+            }
+            let balance = registry.account(&pk).map(|acct| acct.balance).unwrap_or(0);
+            if balance < minted as u64 {
+                return Err(format!(
+                    "registry balance floor failed for {pk}: balance={} minted={}",
+                    balance, minted
+                ));
+            }
+        }
+    }
+
+    Ok(VerifyStateSummary {
+        claim_count,
+        applied_count,
+        missing_count,
+        unknown_count,
+        applied_total_mint: applied_total_mint.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_verify_state, VerifyStateOptions};
+    use serde_json::json;
+    use std::fs;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        p.push(format!("{name}_{ts}"));
+        p
+    }
+
+    #[test]
+    fn verify_state_passes_complete_native() {
+        let registry = temp_path("verify_registry.json");
+        let claims = temp_path("verify_claims.json");
+        let state = temp_path("verify_state.json");
+
+        let registry_payload = json!({
+            "accounts": {
+                "pk1": {"balance": 11, "stake": 0, "slashed": false},
+                "pk2": {"balance": 20, "stake": 0, "slashed": false}
+            }
+        });
+        let claims_payload = json!({
+            "claim_mode": "native",
+            "claims": [
+                {"pubkey_b64":"pk1","account":"pk1","claim_id":"c1","mint_amount":"10"},
+                {"pubkey_b64":"pk2","account":"pk2","claim_id":"c2","mint_amount":"20"}
+            ]
+        });
+        let state_payload = json!({"applied_claim_ids":["c1","c2"]});
+
+        fs::write(&registry, serde_json::to_vec(&registry_payload).unwrap()).unwrap();
+        fs::write(&claims, serde_json::to_vec(&claims_payload).unwrap()).unwrap();
+        fs::write(&state, serde_json::to_vec(&state_payload).unwrap()).unwrap();
+
+        let summary = run_verify_state(
+            registry.to_str().unwrap(),
+            claims.to_str().unwrap(),
+            state.to_str().unwrap(),
+            &VerifyStateOptions {
+                require_complete: true,
+                enforce_balance_floor: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(summary.claim_count, 2);
+        assert_eq!(summary.applied_count, 2);
+        assert_eq!(summary.missing_count, 0);
+        assert_eq!(summary.unknown_count, 0);
+
+        let _ = fs::remove_file(registry);
+        let _ = fs::remove_file(claims);
+        let _ = fs::remove_file(state);
+    }
+
+    #[test]
+    fn verify_state_rejects_unknown_ids() {
+        let registry = temp_path("verify_registry_bad.json");
+        let claims = temp_path("verify_claims_bad.json");
+        let state = temp_path("verify_state_bad.json");
+
+        fs::write(&registry, b"{\"accounts\":{}}" as &[u8]).unwrap();
+        fs::write(
+            &claims,
+            serde_json::to_vec(&json!({
+                "claim_mode":"native",
+                "claims":[{"pubkey_b64":"pk1","account":"pk1","claim_id":"c1","mint_amount":"1"}]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &state,
+            serde_json::to_vec(&json!({"applied_claim_ids":["c1","unknown"]})).unwrap(),
+        )
+        .unwrap();
+
+        let err = run_verify_state(
+            registry.to_str().unwrap(),
+            claims.to_str().unwrap(),
+            state.to_str().unwrap(),
+            &VerifyStateOptions {
+                require_complete: false,
+                enforce_balance_floor: false,
+            },
+        )
+        .err()
+        .unwrap();
+        assert!(err.contains("unknown claim id"));
+
+        let _ = fs::remove_file(registry);
+        let _ = fs::remove_file(claims);
+        let _ = fs::remove_file(state);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,7 +2,15 @@
 
 /// Native claim-application helpers for migration settlement.
 pub mod migration_apply_claims;
+/// Native slashing executor for migration burn intent outboxes.
+pub mod migration_burn_executor;
 /// Deterministic migration claim manifest helpers used by migration tooling.
 pub mod migration_claims;
+/// End-to-end finalize workflow for migration cutover.
+pub mod migration_finalize;
+/// Governance migration proposal artifact builder.
+pub mod migration_proposal;
+/// Verification helpers for migration apply-state and registry consistency.
+pub mod migration_verify_state;
 /// Deterministic stake snapshot helpers used by migration tooling.
 pub mod stake_snapshot;


### PR DESCRIPTION
This completes the native migration hardening track with deterministic finalize, verification guardrails, and native burn-intent execution.

What changed:
- Added migration command group:
  - julian migration finalize
  - julian migration verify-state
  - julian migration execute-burn-intents
- Added new command modules:
  - src/commands/migration_proposal.rs
  - src/commands/migration_finalize.rs
  - src/commands/migration_verify_state.rs
  - src/commands/migration_burn_executor.rs
- Refactored governance propose-migration CLI path to use shared migration proposal builder.
- Updated docs and scripts:
  - README migration section now includes finalize/verify/burn execution flows.
  - scripts/token_migration_dry_run.sh now validates full native finalize + verify + burn execution path.
  - scripts/verify_migration_contract.sh expanded and made portable (rg/grep fallback).

Validation run:
- cargo test --features net --lib --bins
- RUN_NET_SMOKE=0 RUN_TOKEN_BUILD=0 ./scripts/token_migration_dry_run.sh
- ./scripts/smoke_net.sh --with-migration
- ./scripts/verify_migration_contract.sh
