### PR TITLE
Native MetaMask RPC facade for Power-House

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base256emoji"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +659,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -796,6 +815,20 @@ name = "dtoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
 
 [[package]]
 name = "ed25519"
@@ -827,6 +860,25 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -870,6 +922,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1050,6 +1112,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1087,6 +1150,17 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1526,6 +1600,20 @@ checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -2448,6 +2536,7 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "hex",
+ "k256",
  "libp2p",
  "once_cell",
  "proptest",
@@ -2456,6 +2545,7 @@ dependencies = [
  "rayon",
  "reed-solomon-erasure",
  "reqwest",
+ "rlp",
  "rpassword",
  "serde",
  "serde_json",
@@ -2838,6 +2928,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,6 +2964,16 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -2910,6 +3020,12 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -3060,6 +3176,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,6 +3292,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest",
  "rand_core 0.6.4",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,10 +60,12 @@ net = [
     "dep:base64",
     "dep:ed25519-dalek",
     "dep:futures",
+    "dep:k256",
     "dep:libp2p",
     "dep:once_cell",
     "dep:rand_core",
     "dep:reqwest",
+    "dep:rlp",
     "dep:rpassword",
     "dep:tokio",
     "dep:thiserror",
@@ -156,6 +158,11 @@ optional = true
 [dependencies.hex]
 version = "0.4"
 
+[dependencies.k256]
+version = "0.13"
+features = ["ecdsa"]
+optional = true
+
 [dependencies.libp2p]
 version = "0.53"
 features = [
@@ -180,6 +187,10 @@ version = "0.8"
 
 [dependencies.rand_core]
 version = "0.6"
+optional = true
+
+[dependencies.rlp]
+version = "0.5"
 optional = true
 
 [dependencies.reqwest]

--- a/README.md
+++ b/README.md
@@ -254,11 +254,14 @@ Then add a custom network in MetaMask pointing to `http(s)://<node-host>:8545`.
 To credit a wallet address directly in native mode, fund the stake registry with that `0x...` key:
 
 ```bash
-julian stake fund /var/lib/powerhouse/boot1/stake_registry.json 0xYourWalletAddress 1000
+julian stake fund /var/lib/powerhouse/boot1/blobs/stake_registry.json 0xYourWalletAddress 1000
 ```
 
 RPC balance responses are scaled as 18-decimal native units for wallet display.
-Current RPC scope is wallet-read focused (`eth_chainId`, `eth_getBalance`, block/fee surfaces); raw EVM transaction execution (`eth_sendRawTransaction`) remains intentionally disabled until native nonce/signature execution is finalized.
+`eth_sendRawTransaction` is enabled for type-2 (EIP-1559) native value transfers:
+- chainId must match `--evm-chain-id`
+- value must be 18-decimal aligned (whole native units)
+- contract creation/call-data transactions are rejected in native transfer mode
 
 ### 12) Dry-run and smoke coverage
 

--- a/README.md
+++ b/README.md
@@ -229,10 +229,38 @@ python3 ./scripts/deploy_powerhouse_token.py \
 `julian net start` now accepts:
 - `--token-mode <native|TOKEN_ID>`
 - optional `--token-oracle <RPC_URL>` for non-native oracle settlement modes
+- optional native wallet facade flags:
+  - `--evm-rpc-listen <host:port>`
+  - `--evm-chain-id <u64>`
 
 During transition, fee settlement can fall back to oracle balance checks when registry debit fails (non-native modes only).
 
-### 11) Dry-run and smoke coverage
+### 11) Native token visibility in MetaMask (no ERC-20 required)
+
+To expose native `native://julian` balances to wallets, run the built-in RPC facade:
+
+```bash
+julian net start \
+  --node-id boot1 \
+  --log-dir /var/lib/powerhouse/boot1/logs \
+  --listen /ip4/0.0.0.0/tcp/7001 \
+  --blob-dir /var/lib/powerhouse/boot1 \
+  --evm-rpc-listen 0.0.0.0:8545 \
+  --evm-chain-id 177155
+```
+
+Then add a custom network in MetaMask pointing to `http(s)://<node-host>:8545`.
+
+To credit a wallet address directly in native mode, fund the stake registry with that `0x...` key:
+
+```bash
+julian stake fund /var/lib/powerhouse/boot1/stake_registry.json 0xYourWalletAddress 1000
+```
+
+RPC balance responses are scaled as 18-decimal native units for wallet display.
+Current RPC scope is wallet-read focused (`eth_chainId`, `eth_getBalance`, block/fee surfaces); raw EVM transaction execution (`eth_sendRawTransaction`) remains intentionally disabled until native nonce/signature execution is finalized.
+
+### 12) Dry-run and smoke coverage
 
 ```bash
 ./scripts/token_migration_dry_run.sh

--- a/infra/scripts/powerhouse-boot.sh
+++ b/infra/scripts/powerhouse-boot.sh
@@ -87,4 +87,12 @@ if [[ -n "${PH_ATTESTATION_QUORUM:-}" ]]; then
   ARGS+=(--attestation-quorum "$PH_ATTESTATION_QUORUM")
 fi
 
+if [[ -n "${PH_EVM_RPC_LISTEN:-}" ]]; then
+  ARGS+=(--evm-rpc-listen "$PH_EVM_RPC_LISTEN")
+fi
+
+if [[ -n "${PH_EVM_CHAIN_ID:-}" ]]; then
+  ARGS+=(--evm-chain-id "$PH_EVM_CHAIN_ID")
+fi
+
 exec /usr/local/bin/julian net start "${ARGS[@]}"

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -19,6 +19,8 @@ pub mod governance;
 pub mod migration;
 /// Identity admission policy helpers.
 pub mod policy;
+/// MetaMask-compatible EVM JSON-RPC facade for native token balances.
+pub mod rpc;
 /// Machine-readable schema types shared across the network CLI and swarm.
 pub mod schema;
 /// Deterministic key derivation and ed25519 signing helpers.
@@ -41,6 +43,7 @@ pub use governance::{
 };
 pub use migration::{migration_mode_frozen, refresh_migration_mode_from_env};
 pub use policy::{IdentityPolicy, PolicyError};
+pub use rpc::{run_evm_rpc_server, EvmRpcConfig};
 pub use schema::{AnchorEnvelope, AnchorJson, AnchorVoteJson, SCHEMA_VOTE};
 pub use sign::{
     decode_public_key_base64, decode_signature_base64, encode_public_key_base64,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -1,0 +1,601 @@
+#![cfg(feature = "net")]
+
+//! Minimal MetaMask-compatible EVM JSON-RPC facade backed by native stake registry balances.
+
+use crate::net::StakeRegistry;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use blake2::digest::{consts::U32, Digest as BlakeDigest};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::io;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::str;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time;
+
+const MAX_HEADER_BYTES: usize = 32 * 1024;
+const MAX_BODY_BYTES: usize = 512 * 1024;
+const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 10_000;
+const NATIVE_DECIMAL_FACTOR: u128 = 1_000_000_000_000_000_000;
+const DEFAULT_BLOCK_PERIOD_SECS: u64 = 2;
+
+type Blake2b256 = blake2::Blake2b<U32>;
+
+#[derive(Debug)]
+struct HttpRequest {
+    method: String,
+    path: String,
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    #[allow(dead_code)]
+    jsonrpc: Option<String>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+    id: Option<Value>,
+}
+
+#[derive(Debug)]
+struct RpcError {
+    code: i64,
+    message: String,
+}
+
+impl RpcError {
+    fn invalid_params(message: impl Into<String>) -> Self {
+        Self {
+            code: -32602,
+            message: message.into(),
+        }
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self {
+            code: -32000,
+            message: message.into(),
+        }
+    }
+
+    fn method_not_found(method: &str) -> Self {
+        Self {
+            code: -32601,
+            message: format!("method not found: {method}"),
+        }
+    }
+}
+
+/// EVM JSON-RPC listener configuration.
+#[derive(Debug, Clone)]
+pub struct EvmRpcConfig {
+    /// Socket address where the RPC service listens.
+    pub listen: SocketAddr,
+    /// EVM chain ID exposed to wallets.
+    pub chain_id: u64,
+    /// Optional path to the native stake registry for balance lookups.
+    pub stake_registry_path: Option<PathBuf>,
+    /// Max request read timeout.
+    pub request_timeout: Duration,
+    /// Approximate block cadence in seconds for synthetic block number responses.
+    pub block_period_secs: u64,
+}
+
+impl EvmRpcConfig {
+    /// Build a config using sensible defaults.
+    pub fn new(listen: SocketAddr, chain_id: u64, stake_registry_path: Option<PathBuf>) -> Self {
+        Self {
+            listen,
+            chain_id,
+            stake_registry_path,
+            request_timeout: Duration::from_millis(DEFAULT_REQUEST_TIMEOUT_MS),
+            block_period_secs: DEFAULT_BLOCK_PERIOD_SECS,
+        }
+    }
+}
+
+/// Start the EVM RPC service and serve requests until the process exits.
+pub async fn run_evm_rpc_server(cfg: EvmRpcConfig) -> io::Result<()> {
+    let listener = TcpListener::bind(cfg.listen).await?;
+    println!(
+        "QSYS|mod=EVMRPC|evt=LISTEN|addr={}|chain_id={}",
+        cfg.listen, cfg.chain_id
+    );
+    loop {
+        let (mut stream, _) = listener.accept().await?;
+        let cfg = cfg.clone();
+        tokio::spawn(async move {
+            if let Err(err) = handle_connection(&mut stream, &cfg).await {
+                eprintln!("evm rpc connection error: {err}");
+            }
+        });
+    }
+}
+
+async fn handle_connection(stream: &mut TcpStream, cfg: &EvmRpcConfig) -> io::Result<()> {
+    let req = match read_http_request(
+        stream,
+        MAX_HEADER_BYTES,
+        MAX_BODY_BYTES,
+        cfg.request_timeout,
+    )
+    .await
+    {
+        Ok(req) => req,
+        Err(err) => {
+            let body = json!({
+                "jsonrpc": "2.0",
+                "id": Value::Null,
+                "error": {"code": -32700, "message": format!("parse error: {err}")},
+            })
+            .to_string();
+            let resp = build_json_response("400 Bad Request", &body);
+            let _ = stream.write_all(&resp).await;
+            let _ = stream.shutdown().await;
+            return Ok(());
+        }
+    };
+
+    let method = req.method.to_ascii_uppercase();
+    if method == "OPTIONS" {
+        let resp = build_preflight_response();
+        stream.write_all(&resp).await?;
+        stream.shutdown().await?;
+        return Ok(());
+    }
+
+    if method == "GET" && req.path == "/healthz" {
+        let body = json!({
+            "status": "ok",
+            "service": "julian-evm-rpc",
+            "chain_id": cfg.chain_id
+        })
+        .to_string();
+        let resp = build_json_response("200 OK", &body);
+        stream.write_all(&resp).await?;
+        stream.shutdown().await?;
+        return Ok(());
+    }
+
+    if method != "POST" {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": Value::Null,
+            "error": {"code": -32600, "message": "invalid request method"},
+        })
+        .to_string();
+        let resp = build_json_response("405 Method Not Allowed", &body);
+        stream.write_all(&resp).await?;
+        stream.shutdown().await?;
+        return Ok(());
+    }
+
+    // touch headers so the parser keeps ownership meaningful (auth may be layered later)
+    let _content_type = req.headers.get("content-type").cloned();
+
+    let parsed: JsonRpcRequest = match serde_json::from_slice(&req.body) {
+        Ok(v) => v,
+        Err(err) => {
+            let body = json!({
+                "jsonrpc": "2.0",
+                "id": Value::Null,
+                "error": {"code": -32700, "message": format!("parse error: {err}")},
+            })
+            .to_string();
+            let resp = build_json_response("400 Bad Request", &body);
+            stream.write_all(&resp).await?;
+            stream.shutdown().await?;
+            return Ok(());
+        }
+    };
+
+    let id = parsed.id.clone().unwrap_or(Value::Null);
+    let body = match handle_rpc_method(&parsed, cfg) {
+        Ok(result) => json!({"jsonrpc":"2.0","id": id, "result": result}).to_string(),
+        Err(err) => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {"code": err.code, "message": err.message}
+        })
+        .to_string(),
+    };
+    let resp = build_json_response("200 OK", &body);
+    stream.write_all(&resp).await?;
+    stream.shutdown().await
+}
+
+fn handle_rpc_method(req: &JsonRpcRequest, cfg: &EvmRpcConfig) -> Result<Value, RpcError> {
+    match req.method.as_str() {
+        "web3_clientVersion" => Ok(Value::String(format!(
+            "julian/{}/evm-rpc",
+            env!("CARGO_PKG_VERSION")
+        ))),
+        "net_version" => Ok(Value::String(cfg.chain_id.to_string())),
+        "eth_chainId" => Ok(Value::String(to_quantity_u64(cfg.chain_id))),
+        "eth_syncing" => Ok(Value::Bool(false)),
+        "eth_blockNumber" => Ok(Value::String(to_quantity_u64(current_block_number(
+            cfg.block_period_secs,
+        )))),
+        "eth_gasPrice" => Ok(Value::String(to_quantity_u64(1_000_000_000))),
+        "eth_maxPriorityFeePerGas" => Ok(Value::String(to_quantity_u64(100_000_000))),
+        "eth_feeHistory" => Ok(handle_fee_history(req, cfg)),
+        "eth_getBalance" => {
+            let address = rpc_param_string(&req.params, 0)
+                .ok_or_else(|| RpcError::invalid_params("eth_getBalance expects address param"))?;
+            let units = lookup_native_balance(cfg.stake_registry_path.as_deref(), &address)?;
+            let wei = u128::from(units).saturating_mul(NATIVE_DECIMAL_FACTOR);
+            Ok(Value::String(to_quantity_u128(wei)))
+        }
+        "eth_getTransactionCount" => Ok(Value::String("0x0".to_string())),
+        "eth_estimateGas" => Ok(Value::String("0x5208".to_string())),
+        "eth_getCode" => Ok(Value::String("0x".to_string())),
+        "eth_call" => Ok(Value::String("0x".to_string())),
+        "eth_accounts" => Ok(Value::Array(Vec::new())),
+        "eth_coinbase" => Ok(Value::String(
+            "0x0000000000000000000000000000000000000000".to_string(),
+        )),
+        "eth_getBlockByNumber" => Ok(handle_get_block_by_number(req, cfg)),
+        "eth_getBlockByHash" => Ok(Value::Null),
+        "eth_getTransactionByHash" => Ok(Value::Null),
+        "eth_getTransactionReceipt" => Ok(Value::Null),
+        "eth_sendRawTransaction" => Err(RpcError::internal(
+            "native tx execution via raw EVM payload is not enabled yet",
+        )),
+        "rpc_modules" => Ok(json!({
+            "eth": "1.0",
+            "net": "1.0",
+            "web3": "1.0"
+        })),
+        other => Err(RpcError::method_not_found(other)),
+    }
+}
+
+fn handle_fee_history(req: &JsonRpcRequest, cfg: &EvmRpcConfig) -> Value {
+    let block_count = rpc_param_u64(&req.params, 0).unwrap_or(1).clamp(1, 64) as usize;
+    let newest = current_block_number(cfg.block_period_secs);
+    let mut base_fee_per_gas = Vec::with_capacity(block_count + 1);
+    for _ in 0..=block_count {
+        base_fee_per_gas.push(Value::String("0x3b9aca00".to_string()));
+    }
+    let gas_used_ratio = vec![Value::from(0.0); block_count];
+    json!({
+        "oldestBlock": to_quantity_u64(newest.saturating_sub(block_count as u64).saturating_add(1)),
+        "baseFeePerGas": base_fee_per_gas,
+        "gasUsedRatio": gas_used_ratio,
+        "reward": []
+    })
+}
+
+fn handle_get_block_by_number(req: &JsonRpcRequest, cfg: &EvmRpcConfig) -> Value {
+    let block = rpc_param_string(&req.params, 0).unwrap_or_else(|| "latest".to_string());
+    let include_txs = rpc_param_bool(&req.params, 1).unwrap_or(false);
+    let number = parse_block_tag(&block, cfg.block_period_secs);
+    let hash = synthetic_block_hash(number);
+    let parent_hash = synthetic_block_hash(number.saturating_sub(1));
+    let txs = if include_txs {
+        Value::Array(Vec::new())
+    } else {
+        Value::Array(Vec::new())
+    };
+    json!({
+        "number": to_quantity_u64(number),
+        "hash": hash,
+        "parentHash": parent_hash,
+        "nonce": "0x0000000000000000",
+        "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "logsBloom": "0x0",
+        "transactionsRoot": "0x56e81f171bcc55a6ff8345e69d706f96f39c5c6f2a6fbb5f3a8f1c8f7c4b5e71",
+        "stateRoot": "0x56e81f171bcc55a6ff8345e69d706f96f39c5c6f2a6fbb5f3a8f1c8f7c4b5e71",
+        "receiptsRoot": "0x56e81f171bcc55a6ff8345e69d706f96f39c5c6f2a6fbb5f3a8f1c8f7c4b5e71",
+        "miner": "0x0000000000000000000000000000000000000000",
+        "difficulty": "0x0",
+        "totalDifficulty": "0x0",
+        "extraData": "0x6d66656e78",
+        "size": "0x0",
+        "gasLimit": "0x1c9c380",
+        "gasUsed": "0x0",
+        "timestamp": to_quantity_u64(now_secs()),
+        "transactions": txs,
+        "uncles": [],
+        "baseFeePerGas": "0x3b9aca00"
+    })
+}
+
+fn lookup_native_balance(registry_path: Option<&Path>, address: &str) -> Result<u64, RpcError> {
+    let registry_path = match registry_path {
+        Some(path) => path,
+        None => return Ok(0),
+    };
+    let query = normalize_evm_address(address)
+        .ok_or_else(|| RpcError::invalid_params("invalid address format"))?;
+    let registry = StakeRegistry::load(registry_path)
+        .map_err(|err| RpcError::internal(format!("registry load failed: {err}")))?;
+
+    if let Some(acct) = registry.account(&query) {
+        return Ok(acct.balance);
+    }
+    if let Some(acct) = registry.account(address) {
+        return Ok(acct.balance);
+    }
+
+    for (key, account) in registry.accounts() {
+        if let Some(candidate) = registry_key_to_evm_address(key) {
+            if candidate == query {
+                return Ok(account.balance);
+            }
+        }
+    }
+    Ok(0)
+}
+
+fn registry_key_to_evm_address(key: &str) -> Option<String> {
+    if let Some(addr) = normalize_evm_address(key) {
+        return Some(addr);
+    }
+    let pubkey = BASE64.decode(key).ok()?;
+    Some(derive_address_from_pubkey(&pubkey))
+}
+
+fn derive_address_from_pubkey(pubkey: &[u8]) -> String {
+    let mut payload = Vec::with_capacity(32 + pubkey.len());
+    payload.extend_from_slice(b"mfenx-migration-address-v1");
+    payload.extend_from_slice(pubkey);
+    let mut hasher = Blake2b256::new();
+    hasher.update(&payload);
+    let digest: [u8; 32] = hasher.finalize().into();
+    format!("0x{}", hex::encode(&digest[12..]))
+}
+
+fn normalize_evm_address(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if !(trimmed.starts_with("0x") || trimmed.starts_with("0X")) {
+        return None;
+    }
+    if trimmed.len() != 42 {
+        return None;
+    }
+    let raw = &trimmed[2..];
+    if !raw.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(format!("0x{}", raw.to_ascii_lowercase()))
+}
+
+fn parse_block_tag(tag: &str, block_period_secs: u64) -> u64 {
+    let lower = tag.trim().to_ascii_lowercase();
+    if lower == "latest" || lower == "pending" || lower == "safe" || lower == "finalized" {
+        return current_block_number(block_period_secs);
+    }
+    let raw = lower.strip_prefix("0x").unwrap_or(&lower);
+    u64::from_str_radix(raw, 16).unwrap_or_else(|_| current_block_number(block_period_secs))
+}
+
+fn synthetic_block_hash(number: u64) -> String {
+    let mut payload = b"mfenx-native-block-v1:".to_vec();
+    payload.extend_from_slice(&number.to_be_bytes());
+    let mut hasher = Blake2b256::new();
+    hasher.update(&payload);
+    let digest: [u8; 32] = hasher.finalize().into();
+    format!("0x{}", hex::encode(digest))
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn current_block_number(block_period_secs: u64) -> u64 {
+    let period = block_period_secs.max(1);
+    now_secs() / period
+}
+
+fn to_quantity_u64(value: u64) -> String {
+    format!("0x{value:x}")
+}
+
+fn to_quantity_u128(value: u128) -> String {
+    format!("0x{value:x}")
+}
+
+fn rpc_param_string(params: &Value, index: usize) -> Option<String> {
+    params
+        .as_array()
+        .and_then(|arr| arr.get(index))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn rpc_param_bool(params: &Value, index: usize) -> Option<bool> {
+    params
+        .as_array()
+        .and_then(|arr| arr.get(index))
+        .and_then(Value::as_bool)
+}
+
+fn rpc_param_u64(params: &Value, index: usize) -> Option<u64> {
+    let value = params.as_array()?.get(index)?;
+    if let Some(v) = value.as_u64() {
+        return Some(v);
+    }
+    let s = value.as_str()?;
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        return u64::from_str_radix(hex, 16).ok();
+    }
+    s.parse::<u64>().ok()
+}
+
+async fn read_http_request(
+    stream: &mut TcpStream,
+    max_header_bytes: usize,
+    max_body_bytes: usize,
+    timeout: Duration,
+) -> io::Result<HttpRequest> {
+    let mut buf = Vec::new();
+    let mut header_end = None;
+    loop {
+        let mut tmp = [0u8; 1024];
+        let n = time::timeout(timeout, stream.read(&mut tmp))
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "read timeout"))??;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.len() > max_header_bytes && header_end.is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "header too large",
+            ));
+        }
+        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            header_end = Some(pos + 4);
+            break;
+        }
+    }
+
+    let end = header_end
+        .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "malformed request"))?;
+    let header_str = str::from_utf8(&buf[..end])
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid header"))?;
+    let mut lines = header_str.split("\r\n").filter(|line| !line.is_empty());
+    let request_line = lines
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing request line"))?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("").to_string();
+    let path = parts.next().unwrap_or("").to_string();
+    let mut headers = HashMap::new();
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':') {
+            headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+
+    let content_len: usize = headers
+        .get("content-length")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    if content_len > max_body_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "content-length exceeds limit",
+        ));
+    }
+
+    let mut body = if end < buf.len() {
+        buf[end..].to_vec()
+    } else {
+        Vec::new()
+    };
+    while body.len() < content_len {
+        let remaining = content_len - body.len();
+        let mut tmp = vec![0u8; remaining.min(8192)];
+        let n = time::timeout(timeout, stream.read(&mut tmp))
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "read timeout"))??;
+        if n == 0 {
+            break;
+        }
+        body.extend_from_slice(&tmp[..n]);
+    }
+    if body.len() < content_len {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "incomplete request body",
+        ));
+    }
+
+    Ok(HttpRequest {
+        method,
+        path,
+        headers,
+        body,
+    })
+}
+
+fn build_json_response(status: &str, body: &str) -> Vec<u8> {
+    format!(
+        "HTTP/1.1 {status}\r\n\
+         Content-Type: application/json\r\n\
+         Access-Control-Allow-Origin: *\r\n\
+         Access-Control-Allow-Methods: POST, OPTIONS, GET\r\n\
+         Access-Control-Allow-Headers: content-type\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )
+    .into_bytes()
+}
+
+fn build_preflight_response() -> Vec<u8> {
+    b"HTTP/1.1 204 No Content\r\n\
+      Access-Control-Allow-Origin: *\r\n\
+      Access-Control-Allow-Methods: POST, OPTIONS, GET\r\n\
+      Access-Control-Allow-Headers: content-type\r\n\
+      Content-Length: 0\r\n\
+      Connection: close\r\n\r\n"
+        .to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        derive_address_from_pubkey, lookup_native_balance, normalize_evm_address, to_quantity_u128,
+    };
+    use crate::net::StakeRegistry;
+    use std::fs;
+
+    #[test]
+    fn normalize_hex_address() {
+        let addr = normalize_evm_address("0xAbCdEfabcdefABCDefAbcdefABcdefabCDefAb12");
+        assert_eq!(
+            addr.as_deref(),
+            Some("0xabcdefabcdefabcdefabcdefabcdefabcdefab12")
+        );
+    }
+
+    #[test]
+    fn derive_address_is_stable() {
+        let pubkey = vec![7u8; 32];
+        let addr = derive_address_from_pubkey(&pubkey);
+        assert!(addr.starts_with("0x"));
+        assert_eq!(addr.len(), 42);
+    }
+
+    #[test]
+    fn quantity_encoding_u128() {
+        assert_eq!(to_quantity_u128(0), "0x0");
+        assert_eq!(to_quantity_u128(15), "0xf");
+    }
+
+    #[test]
+    fn lookup_balance_reads_direct_evm_key() {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "rpc_registry_{}.json",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+
+        let mut reg = StakeRegistry::default();
+        reg.fund_balance("0xabcdefabcdefabcdefabcdefabcdefabcdefab12", 77);
+        reg.save(&path).expect("save registry");
+
+        let got = lookup_native_balance(Some(&path), "0xABCDefabCDefabCDefABcDEFAbCdEfABcDeFAb12")
+            .expect("lookup");
+        assert_eq!(got, 77);
+
+        let _ = fs::remove_file(path);
+    }
+}


### PR DESCRIPTION
Adds a native EVM JSON-RPC facade so MetaMask can read and submit signed native transfers without ERC-20.

### What changed
- Added `src/net/rpc.rs` with a MetaMask-compatible JSON-RPC service.
- Added `--evm-rpc-listen` and `--evm-chain-id` to `julian net start`.
- Wired RPC service startup into `run_network`.
- Added ops env passthrough in `infra/scripts/powerhouse-boot.sh`.
- Documented native MetaMask flow in README.

### Added tx execution phase
- Enabled `eth_sendRawTransaction` for type-2 (EIP-1559) native value transfers.
- Added nonce tracking, tx persistence, and receipt persistence in `evm_rpc_state.json`.
- Added `eth_getTransactionCount`, `eth_getTransactionByHash`, and `eth_getTransactionReceipt` backed by persisted state.

### Current transfer constraints
- Chain ID must match `--evm-chain-id`.
- Value must be 18-decimal aligned (whole native units).
- Contract creation / calldata transactions are rejected in native transfer mode.

### Validation
- `cargo test --features net --lib --bins`
- live signed tx tests against both production RPC endpoints after rollout
