### PR TITLE
Activate RPC proxy after cloud initialization

### DIFF
--- a/infra/digitalocean/cloud-init.yaml
+++ b/infra/digitalocean/cloud-init.yaml
@@ -60,6 +60,7 @@ runcmd:
   - [rm, -f, /etc/nginx/sites-enabled/default]
   - [nginx, -t]
   - [systemctl, enable, --now, nginx]
+  - [systemctl, reload, nginx]
   - [systemctl, restart, ssh]
   - [systemctl, enable, --now, unattended-upgrades]
 

--- a/scripts/test_digitalocean_provision.sh
+++ b/scripts/test_digitalocean_provision.sh
@@ -18,6 +18,8 @@ grep -q "compute domain create \"\$DNS_ZONE\"" \
   "$ROOT/scripts/provision_digitalocean_rpc.sh"
 grep -q "BLOCKED: \$DNS_ZONE is not delegated to DigitalOcean." \
   "$ROOT/scripts/provision_digitalocean_rpc.sh"
+grep -q -- '- \[systemctl, reload, nginx\]' \
+  "$ROOT/infra/digitalocean/cloud-init.yaml"
 
 if "$ROOT/scripts/provision_digitalocean_rpc.sh" \
   --ssh-key test-fingerprint \


### PR DESCRIPTION
## Summary

- reload Nginx after cloud-init installs and enables the RPC site
- add a provisioning contract assertion that preserves the activation order

## Root cause

Ubuntu starts Nginx during package installation. Enabling an already-running service after linking the RPC site does not reload its workers, so the package configuration remained active and returned 404 for `/healthz`. The DigitalOcean Global Load Balancer consequently marked all three otherwise healthy validators down.

## Live verification

- reloaded Nginx on all three production validators
- each origin now returns the finalized RPC health payload through port 80
- all three load-balancer backends became healthy
- `https://rpc.mfenx.com` passes the complete publication gate for chain ID 177155, HTTPS, JSON-RPC, finalized hash, DNS, and CORS
- all validators share the same genesis hash and state root
- all three validator pairs have established libp2p TCP sessions

## Tests

- `bash -n scripts/test_digitalocean_provision.sh`
- `shellcheck scripts/test_digitalocean_provision.sh`
- `scripts/test_digitalocean_provision.sh`
- cloud-init YAML parse and command-order assertion
- `git diff --check`