### PR TITLE
Release Power House Rootprint v0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,16 @@ jobs:
           cargo run --example conformance_vectors
           git diff --exit-code -- conformance/v1
 
+      - name: Reproduce PHA and Rootprint conformance vectors
+        run: |
+          cargo run --example pha_conformance_vectors
+          git diff --exit-code -- \
+            conformance/pha-v1 \
+            publicpower/artifacts/rootprint-valid.json
+
+      - name: Cross-language PHA and Rootprint verification
+        run: PYTHONPATH=sdk/python python3 -m unittest discover -s sdk/python/tests -v
+
       - name: Large-domain examples
         run: |
           cargo run --release --example sextillion_verify

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "power_house"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "power_house"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["MFENX LLC"]
 description = "Deterministic sum-check proofs, commitment-bound sparse verification, and quorum ledger tooling."
@@ -21,6 +21,7 @@ include = [
   "JULIAN_PROTOCOL.md",
   "docs/*.md",
   "artifacts/*.json",
+  "benchmarks/**",
   "conformance/**",
   "infra/ops/*.py",
   "infra/ops/*.sh",
@@ -28,6 +29,7 @@ include = [
   "infra/scripts/*.sh",
   "infra/systemd/*",
   "scripts/benchmark_sparse.py",
+  "scripts/benchmark_v030.py",
   "scripts/check_rpc.py",
   "scripts/deploy_rpc_cluster.sh",
   "scripts/digitalocean_rpc_preflight.sh",
@@ -40,6 +42,7 @@ include = [
   "scripts/test_rpc_check.py",
   "scripts/test_sparse_verifier.py",
   "scripts/verify_sparse_certificate.py",
+  "sdk/python/**",
   "src/**",
   "examples/**",
   "tests/**",

--- a/JULIAN_PROTOCOL.md
+++ b/JULIAN_PROTOCOL.md
@@ -1,5 +1,5 @@
 MFENX Power-House Network: The JULIAN Protocol Network
-Version 0.2.2 - June 2026
+Version 0.3.0 - June 2026
 
 
 # JULIAN Protocol: Proof-Transparent Consensus via Folding-Derived Anchors

--- a/README.md
+++ b/README.md
@@ -6,8 +6,38 @@
 [![license](https://img.shields.io/crates/l/power_house)](LICENSE)
 
 `power_house` is a Rust verification stack for deterministic sum-check proofs,
-commitment-bound sparse workloads, transcript anchoring, and optional quorum
-networking.
+portable proof provenance, commitment-bound sparse workloads, transcript
+anchoring, and optional quorum networking.
+
+Power House Archive (`.pha`) and Rootprint are the primary provenance workflow.
+A `.pha` file binds core proof data and provenance to a deterministic
+`phx_fingerprint`. Rootprint adds verifiable navigation, forks, merges, and
+equivalence over those core identities.
+
+External proof attachments are optional transport data. They never affect a
+Power House fingerprint, Rootprint branch ID, core verification, or branch
+equivalence.
+
+## Power House + Rootprint
+
+```rust
+use power_house::{prove_with_rootprint, provenance::PhaArtifact};
+use serde_json::json;
+
+let artifact = PhaArtifact::new(
+    json!({"producer": "example"}),
+    "power-house/example/v1",
+    json!({"claim": 7}),
+    json!({"accepted": true}),
+)?;
+let graph = prove_with_rootprint!(label: "main", artifact: artifact)?;
+graph.verify()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The `julian rootprint` workflow navigates, forks, merges, compares, and verifies
+portable graphs. `julian attach-external-proof` is deliberately separate from
+the core engine.
 
 ## Verified Scale
 
@@ -47,6 +77,8 @@ cargo run --release --example sextillion_verify
 cargo run --release --example hyperscale_affine
 cargo run --release --example sparse_record
 cargo run --release --example committed_workload
+cargo run --example rootprint_workflow
+cargo run --example pha_conformance_vectors
 
 python3 scripts/verify_sparse_certificate.py \
   target/power_house_sparse_record.phsp
@@ -57,6 +89,7 @@ python3 scripts/verify_sparse_certificate.py \
 
 python3 scripts/test_sparse_verifier.py
 python3 scripts/soundness_budget.py
+PYTHONPATH=sdk/python python3 -m unittest discover -s sdk/python/tests -v
 ```
 
 The full procedure, formats, expected outputs, and failure tests are in
@@ -89,6 +122,9 @@ Primary APIs:
 - `SeededSparseProof`: stable `PHSPv1` seeded sparse certificates
 - `CommittedSparsePolynomial`: canonical external sparse workloads
 - `CommittedSparseProof`: stable `PHCPv1` commitment-bound certificates
+- `PhaArtifact`: portable core proof and provenance identity
+- `Rootprint`: deterministic proof-history branching and equivalence
+- `prove_with_rootprint!`: recommended provenance-aware construction interface
 - `ProofLedger`: transcript logs, anchors, and quorum reconciliation
 
 ## Network
@@ -137,6 +173,10 @@ Operations and migration procedures are documented in
 ## Documentation
 
 - [Verification Guide](docs/verification_guide.md)
+- [Power House Archive v1](docs/pha_spec.md)
+- [Rootprint v1](docs/rootprint.md)
+- [SDKs](docs/sdk.md)
+- [v0.3.0 Benchmarks](benchmarks/v0.3.0/report.json)
 - [JULIAN Protocol](JULIAN_PROTOCOL.md)
 - [Committed Workload Format](docs/committed_workload.md)
 - [Million-Round Sparse Certificate](docs/sparse_record.md)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,28 @@
 # Release Notes
 
+## v0.3.0 - 2026-06-12
+
+### Added
+- Power House Archive (`.pha`) v1 with deterministic core fingerprints.
+- Rootprint v1 navigation, forking, merging, equivalence, and graph verification.
+- The `prove_with_rootprint!` macro and `julian rootprint` command family.
+- Zero-dependency Python SDK with Rust-compatible conformance vectors.
+- Browser-native Rootprint and `.pha` verification on mfenx.com.
+- Reproducible v0.3.0 provenance, branching, scale, and verification benchmarks.
+
+### External Proof Attachments
+- Added EPA as optional transport data inside `embedded_proof`.
+- Omitted the field when unused through `skip_serializing_if = "Option::is_none"`.
+- Excluded EPA from core fingerprints, branch IDs, graph validity, and equivalence.
+- Added explicit attachment integrity and caller-supplied semantic verification.
+- Added mutation tests proving EPA changes preserve core validity while core
+  mutations reject.
+
+### Performance
+- Changed Rootprint reachability verification to linear graph traversal.
+- Published measured release results for `2^70`, `2^4096`, core provenance, and
+  a 2,049-branch graph. Timings are machine-dependent measurements.
+
 ## v0.2.2 - 2026-06-05
 
 ### Added

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,20 @@
+# Benchmarks
+
+`v0.3.0/report.json` is produced by:
+
+```bash
+python3 scripts/benchmark_v030.py
+```
+
+The report measures:
+
+- closed-form verification over `2^70`;
+- seeded-affine verification over `2^4096`;
+- `.pha` fingerprinting and core verification;
+- construction and full verification of a 2,049-branch Rootprint graph;
+- repeated fingerprint reproducibility;
+- published Rust/Python conformance and mutation coverage.
+
+Timing values are machine-dependent measurements, not complexity guarantees.
+The relevant algorithmic bounds and domain restrictions remain documented in
+the protocol specifications.

--- a/benchmarks/v0.3.0/report.json
+++ b/benchmarks/v0.3.0/report.json
@@ -1,0 +1,49 @@
+{
+  "branching": {
+    "branches": 2049,
+    "fork_mean_us": 33.3962880859375,
+    "fork_total_us": 68395.598,
+    "full_graph_verify_us": 25262.056
+  },
+  "environment": {
+    "arch": "x86_64",
+    "os": "linux",
+    "profile": "release"
+  },
+  "provenance": {
+    "fingerprint_mean_us": 3.7993911999999996,
+    "fingerprint_total_us": 37993.912,
+    "iterations": 10000,
+    "verify_mean_us": 3.8158258999999997,
+    "verify_total_us": 38158.259
+  },
+  "public_verification": {
+    "core_mutation_classes": 6,
+    "epa_mutation_isolated": true,
+    "python_cross_language_vectors": 3,
+    "rust_conformance_vectors": 3
+  },
+  "release": "0.3.0",
+  "reproducibility": {
+    "identical_fingerprints": true,
+    "phx_fingerprint": "sha256:7aa94fe612b22e5be12ff8d3d70875424f85afd9f3a9afb24861be6c811dd40c",
+    "runs": 1000,
+    "total_us": 4119.291
+  },
+  "scale": {
+    "constant": {
+      "domain": "2^70",
+      "domain_points": "1180591620717411303424",
+      "proof_rounds": 70,
+      "prove_us": 218.355,
+      "verify_us": 207.164
+    },
+    "seeded_affine": {
+      "domain": "2^4096",
+      "proof_rounds": 4096,
+      "prove_us": 440883.769,
+      "verify_us": 450011.402
+    }
+  },
+  "schema": "power-house-benchmark-v0.3.0"
+}

--- a/conformance/pha-v1/core-valid.pha
+++ b/conformance/pha-v1/core-valid.pha
@@ -1,0 +1,19 @@
+{
+  "schema": "power-house/pha/v1",
+  "provenance": {
+    "producer": "power-house-conformance",
+    "stage": "baseline"
+  },
+  "embedded_proof": {
+    "protocol": "power-house/rootprint-example/v1",
+    "public_inputs": {
+      "claim": 70,
+      "field": 1000000007
+    },
+    "proof": {
+      "accepted": true,
+      "rounds": 70
+    }
+  },
+  "phx_fingerprint": "sha256:9cd9c336ffdabb701a907657c75d44e8fe5251fe951cc3cfc90ef228e29cacae"
+}

--- a/conformance/pha-v1/core-with-epa.pha
+++ b/conformance/pha-v1/core-with-epa.pha
@@ -1,0 +1,34 @@
+{
+  "schema": "power-house/pha/v1",
+  "provenance": {
+    "producer": "power-house-conformance",
+    "stage": "baseline"
+  },
+  "embedded_proof": {
+    "protocol": "power-house/rootprint-example/v1",
+    "public_inputs": {
+      "claim": 70,
+      "field": 1000000007
+    },
+    "proof": {
+      "accepted": true,
+      "rounds": 70
+    },
+    "external_proof_attachments": [
+      {
+        "id": "external-example-1",
+        "proof_system": "example/external-proof/v1",
+        "payload": {
+          "proof": "opaque-example",
+          "public_inputs": [
+            1,
+            2,
+            3
+          ]
+        },
+        "payload_sha256": "sha256:8188d0344f4a44aaa455ae4dd7e79d63e5793295b73ff24b79867eaf905281f4"
+      }
+    ]
+  },
+  "phx_fingerprint": "sha256:9cd9c336ffdabb701a907657c75d44e8fe5251fe951cc3cfc90ef228e29cacae"
+}

--- a/conformance/pha-v1/manifest.json
+++ b/conformance/pha-v1/manifest.json
@@ -1,0 +1,14 @@
+{
+  "core_fingerprint": "sha256:9cd9c336ffdabb701a907657c75d44e8fe5251fe951cc3cfc90ef228e29cacae",
+  "external_attachments_affect_core_identity": false,
+  "files": {
+    "core-valid.pha": "d9267160308805adf6f91560c0c406f1c6dae58be7040524ae1b7685c7e5d3c6",
+    "core-with-epa.pha": "08c3f547720bee18b33bbd8b17422a40f2839fcef9d9313019641c1a3dbbfbae",
+    "rootprint-valid.json": "eeb33450c6473c082675b8fcdaf70abfb0e6070fe739eeda5c839070d13750a3"
+  },
+  "mutation_rules": {
+    "core_field_mutation": "must fail core verification",
+    "epa_payload_mutation": "must preserve core verification and fail explicit EPA integrity verification"
+  },
+  "schema": "power-house-pha-conformance-v1"
+}

--- a/conformance/pha-v1/rootprint-valid.json
+++ b/conformance/pha-v1/rootprint-valid.json
@@ -1,0 +1,128 @@
+{
+  "schema": "power-house/rootprint/v1",
+  "root_branch": "sha256:699a058e048208946b879ffe7b59d538f1e2586677585d3adb63e783d8480fd4",
+  "branches": {
+    "sha256:699a058e048208946b879ffe7b59d538f1e2586677585d3adb63e783d8480fd4": {
+      "id": "sha256:699a058e048208946b879ffe7b59d538f1e2586677585d3adb63e783d8480fd4",
+      "label": "main",
+      "sequence": 0,
+      "parents": [],
+      "artifact": {
+        "schema": "power-house/pha/v1",
+        "provenance": {
+          "producer": "power-house-conformance",
+          "stage": "baseline"
+        },
+        "embedded_proof": {
+          "protocol": "power-house/rootprint-example/v1",
+          "public_inputs": {
+            "claim": 70,
+            "field": 1000000007
+          },
+          "proof": {
+            "accepted": true,
+            "rounds": 70
+          }
+        },
+        "phx_fingerprint": "sha256:9cd9c336ffdabb701a907657c75d44e8fe5251fe951cc3cfc90ef228e29cacae"
+      }
+    },
+    "sha256:7741da3abefbe66fcd8bd547be0f5c16544154437b031b93a78da7266f38e4ba": {
+      "id": "sha256:7741da3abefbe66fcd8bd547be0f5c16544154437b031b93a78da7266f38e4ba",
+      "label": "audit",
+      "sequence": 1,
+      "parents": [
+        "sha256:699a058e048208946b879ffe7b59d538f1e2586677585d3adb63e783d8480fd4"
+      ],
+      "artifact": {
+        "schema": "power-house/pha/v1",
+        "provenance": {
+          "producer": "power-house-conformance",
+          "stage": "audit"
+        },
+        "embedded_proof": {
+          "protocol": "power-house/rootprint-example/v1",
+          "public_inputs": {
+            "claim": 70,
+            "field": 1000000007
+          },
+          "proof": {
+            "accepted": true,
+            "rounds": 70
+          }
+        },
+        "phx_fingerprint": "sha256:72f0bf01f23399c4bea1f0fc41b6a330a80dbf559c0c3184b9560b9e2cbe8a42"
+      }
+    },
+    "sha256:8ff2524d624945a81bc89934213b2652672f827bdd6fd32b5cce9be987231711": {
+      "id": "sha256:8ff2524d624945a81bc89934213b2652672f827bdd6fd32b5cce9be987231711",
+      "label": "accepted",
+      "sequence": 2,
+      "parents": [
+        "sha256:7741da3abefbe66fcd8bd547be0f5c16544154437b031b93a78da7266f38e4ba",
+        "sha256:f223e4ec43c132b0729dbf9b00ca32a639d00c00278bc71c5adc340d663e6a17"
+      ],
+      "artifact": {
+        "schema": "power-house/pha/v1",
+        "provenance": {
+          "producer": "power-house-conformance",
+          "stage": "accepted"
+        },
+        "embedded_proof": {
+          "protocol": "power-house/rootprint-example/v1",
+          "public_inputs": {
+            "claim": 70,
+            "field": 1000000007
+          },
+          "proof": {
+            "accepted": true,
+            "rounds": 70
+          }
+        },
+        "phx_fingerprint": "sha256:6e4f62bd1a2dce7961d8e88c0cbabba888ddc5e874be02d6fdf9c847e96c4966"
+      }
+    },
+    "sha256:f223e4ec43c132b0729dbf9b00ca32a639d00c00278bc71c5adc340d663e6a17": {
+      "id": "sha256:f223e4ec43c132b0729dbf9b00ca32a639d00c00278bc71c5adc340d663e6a17",
+      "label": "candidate",
+      "sequence": 1,
+      "parents": [
+        "sha256:699a058e048208946b879ffe7b59d538f1e2586677585d3adb63e783d8480fd4"
+      ],
+      "artifact": {
+        "schema": "power-house/pha/v1",
+        "provenance": {
+          "producer": "power-house-conformance",
+          "stage": "baseline"
+        },
+        "embedded_proof": {
+          "protocol": "power-house/rootprint-example/v1",
+          "public_inputs": {
+            "claim": 70,
+            "field": 1000000007
+          },
+          "proof": {
+            "accepted": true,
+            "rounds": 70
+          },
+          "external_proof_attachments": [
+            {
+              "id": "external-example-1",
+              "proof_system": "example/external-proof/v1",
+              "payload": {
+                "proof": "opaque-example",
+                "public_inputs": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "payload_sha256": "sha256:8188d0344f4a44aaa455ae4dd7e79d63e5793295b73ff24b79867eaf905281f4"
+            }
+          ]
+        },
+        "phx_fingerprint": "sha256:9cd9c336ffdabb701a907657c75d44e8fe5251fe951cc3cfc90ef228e29cacae"
+      }
+    }
+  }
+}

--- a/docs/pha_spec.md
+++ b/docs/pha_spec.md
@@ -1,0 +1,123 @@
+# Power House Archive (`.pha`) v1
+
+## Status
+
+This document defines the portable Power House Archive v1 JSON format. The
+schema identifier is:
+
+```text
+power-house/pha/v1
+```
+
+A `.pha` artifact has one authoritative Power House core. Optional external
+proof attachments may travel with that core, but they do not participate in
+Power House identity, proof validity, branching, or equivalence.
+
+## Top-level object
+
+```json
+{
+  "schema": "power-house/pha/v1",
+  "provenance": {},
+  "embedded_proof": {
+    "protocol": "power-house/sumcheck/v1",
+    "public_inputs": {},
+    "proof": {}
+  },
+  "phx_fingerprint": "sha256:<64 lowercase hex characters>"
+}
+```
+
+| Field | Required | Meaning |
+|---|---:|---|
+| `schema` | yes | Must equal `power-house/pha/v1`. |
+| `provenance` | yes | JSON provenance committed by the core fingerprint. |
+| `embedded_proof` | yes | Power House protocol identifier, public inputs, proof, and optional attachments. |
+| `phx_fingerprint` | yes | Domain-separated SHA-256 identity of core fields. |
+
+## Embedded proof
+
+`embedded_proof` contains:
+
+| Field | Required | Core-bound |
+|---|---:|---:|
+| `protocol` | yes | yes |
+| `public_inputs` | yes | yes |
+| `proof` | yes | yes |
+| `external_proof_attachments` | no | **no** |
+
+The Rust field is declared with:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub external_proof_attachments: Option<Vec<ExternalProofAttachment>>
+```
+
+Artifacts that do not use EPA therefore serialize exactly without the field.
+
+## External proof attachment
+
+```json
+{
+  "id": "external-proof-1",
+  "proof_system": "example/external-proof/v1",
+  "payload": {},
+  "payload_sha256": "sha256:<64 lowercase hex characters>",
+  "verifier_hint": "optional verifier name or URI",
+  "metadata": {}
+}
+```
+
+`verifier_hint` and `metadata` are optional and omitted when absent.
+`payload_sha256` is SHA-256 over the compact canonical JSON serialization of
+`payload`. Built-in attachment verification checks structure and payload
+integrity. Cryptographic verification of an external proof system is performed
+only by an explicitly supplied external verifier.
+
+Canonical JSON objects use lexicographically sorted keys, UTF-8, and no
+insignificant whitespace. JSON numbers in fingerprinted core fields and EPA
+payloads must be signed or unsigned integers. Floating-point values are
+rejected so independent implementations cannot disagree about number
+serialization.
+
+## Core fingerprint
+
+`phx_fingerprint` is:
+
+```text
+sha256(
+  "power-house:pha:v1:phx-fingerprint\0" ||
+  canonical_json({
+    "embedded_proof": {
+      "proof": embedded_proof.proof,
+      "protocol": embedded_proof.protocol,
+      "public_inputs": embedded_proof.public_inputs
+    },
+    "provenance": provenance,
+    "schema": schema
+  })
+)
+```
+
+The following are excluded:
+
+- `phx_fingerprint` itself
+- `embedded_proof.external_proof_attachments`
+- every EPA payload, digest, verifier hint, and metadata value
+
+Adding, removing, reordering, or mutating EPA data cannot change the core
+fingerprint. Mutating a core field must change it.
+
+## Verification modes
+
+`PhaArtifact::verify()` validates only the Power House core schema and
+fingerprint. It does not read EPA data.
+
+`PhaArtifact::verify_external_proof_attachments()` first validates the core,
+then explicitly checks EPA structure and payload integrity.
+
+`PhaArtifact::verify_external_proof_attachments_with(...)` additionally invokes
+a caller-supplied verifier for external proof semantics.
+
+No Power House workflow is permitted to require EPA verification for core
+validity.

--- a/docs/rootprint.md
+++ b/docs/rootprint.md
@@ -1,0 +1,111 @@
+# Rootprint v1
+
+Rootprint is the primary Power House provenance workflow. It is a deterministic
+directed acyclic graph whose nodes carry `.pha` artifacts and whose edges record
+fork and merge ancestry.
+
+## Core rule
+
+Rootprint identity and validity depend only on Power House data:
+
+- parent branch IDs
+- branch label
+- the artifact `phx_fingerprint`
+
+External proof attachments are never inputs to branch IDs, graph verification,
+navigation, equivalence, forking, or merging. A branch can carry EPA because
+its `.pha` artifact can carry EPA, but Rootprint does not require or interpret
+it.
+
+## Rust interface
+
+```rust
+use power_house::{prove_with_rootprint, provenance::PhaArtifact};
+use serde_json::json;
+
+let main_artifact = PhaArtifact::new(
+    json!({"source": "experiment-7"}),
+    "power-house/sumcheck/v1",
+    json!({"claim": 42}),
+    json!({"rounds": []}),
+)?;
+
+let mut rootprint =
+    prove_with_rootprint!(label: "main", artifact: main_artifact)?;
+
+let branch_artifact = PhaArtifact::new(
+    json!({"source": "experiment-7"}),
+    "power-house/sumcheck/v1",
+    json!({"claim": 43}),
+    json!({"rounds": []}),
+)?;
+
+let branch_id = prove_with_rootprint!(
+    rootprint: &mut rootprint,
+    fork: "main",
+    label: "candidate",
+    artifact: branch_artifact,
+)?;
+
+rootprint.verify()?;
+# let _ = branch_id;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The macro also supports merges:
+
+```rust,ignore
+prove_with_rootprint!(
+    rootprint: &mut rootprint,
+    merge: [left_id, right_id],
+    label: "accepted",
+    artifact: merged_artifact,
+)?;
+```
+
+## CLI workflow
+
+```bash
+julian rootprint init main.pha \
+  --label main \
+  --output experiment.rootprint.json
+
+julian rootprint fork experiment.rootprint.json main candidate.pha \
+  --label candidate
+
+julian rootprint merge experiment.rootprint.json candidate audit audit.pha \
+  --label accepted
+
+julian rootprint navigate experiment.rootprint.json accepted
+julian rootprint equivalent experiment.rootprint.json candidate audit
+julian rootprint verify experiment.rootprint.json
+```
+
+Selectors resolve exact branch IDs, unique ID prefixes, or unique labels.
+`rootprint verify` is always a Power House core operation.
+
+## Deterministic branch ID
+
+Every branch ID is domain-separated SHA-256 over canonical JSON with
+lexicographically sorted object keys:
+
+```text
+sha256(
+  "power-house:rootprint:v1:branch-id\0" ||
+  compact_json({
+    "artifact_phx_fingerprint": artifact.phx_fingerprint,
+    "label": label,
+    "parents": sorted_parent_ids
+  })
+)
+```
+
+The root has no parents, forks have one parent, and merges have two sorted,
+unique parents. Sequence numbers prove parent-before-child ordering but are not
+part of branch identity.
+
+## Optional EPA
+
+EPA integrity can be checked explicitly through
+`Rootprint::verify_external_proof_attachments()`. It is not called by
+`Rootprint::verify()` and is not part of the standard CLI workflow.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,45 @@
+# SDKs
+
+Power House v0.3.0 ships matching Rust and zero-dependency Python interfaces
+for `.pha` and Rootprint v1.
+
+## Rust
+
+```rust
+use power_house::{prove_with_rootprint, provenance::PhaArtifact};
+use serde_json::json;
+
+let artifact = PhaArtifact::new(
+    json!({"source": "rust"}),
+    "power-house/example/v1",
+    json!({"claim": 7}),
+    json!({"accepted": true}),
+)?;
+let graph = prove_with_rootprint!(label: "main", artifact: artifact)?;
+graph.verify()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Python
+
+```bash
+python3 -m pip install ./sdk/python
+```
+
+```python
+from power_house import create_artifact, new_rootprint, verify_rootprint
+
+artifact = create_artifact(
+    {"source": "python"},
+    "power-house/example/v1",
+    {"claim": 7},
+    {"accepted": True},
+)
+graph = new_rootprint("main", artifact)
+verify_rootprint(graph)
+```
+
+The default Python namespace contains no EPA functions. Optional attachment
+transport requires an explicit import from `power_house.external`.
+
+Both implementations consume the vectors in `conformance/pha-v1`.

--- a/docs/verification_guide.md
+++ b/docs/verification_guide.md
@@ -1,6 +1,6 @@
 # Verification Guide
 
-This guide reproduces every large-domain proof mode in `power_house` v0.2.2.
+This guide reproduces every large-domain proof mode in `power_house` v0.3.0.
 
 ## Requirements
 

--- a/examples/pha_conformance_vectors.rs
+++ b/examples/pha_conformance_vectors.rs
@@ -1,0 +1,81 @@
+use power_house::provenance::{ExternalProofAttachment, PhaArtifact, Rootprint};
+use serde::Serialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+fn write_json(path: &Path, value: &impl Serialize) -> Vec<u8> {
+    let mut bytes = serde_json::to_vec_pretty(value).expect("serialize vector");
+    bytes.push(b'\n');
+    fs::write(path, &bytes).expect("write vector");
+    bytes
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn artifact(stage: &str) -> PhaArtifact {
+    PhaArtifact::new(
+        json!({
+            "producer": "power-house-conformance",
+            "stage": stage,
+        }),
+        "power-house/rootprint-example/v1",
+        json!({"claim": 70, "field": 1_000_000_007_u64}),
+        json!({"accepted": true, "rounds": 70}),
+    )
+    .expect("valid artifact")
+}
+
+fn main() {
+    let directory = Path::new("conformance/pha-v1");
+    fs::create_dir_all(directory).expect("create conformance directory");
+
+    let core = artifact("baseline");
+    let mut attached = core.clone();
+    attached.embedded_proof.external_proof_attachments = Some(vec![ExternalProofAttachment::new(
+        "external-example-1",
+        "example/external-proof/v1",
+        json!({"proof": "opaque-example", "public_inputs": [1, 2, 3]}),
+    )
+    .expect("valid attachment")]);
+
+    let mut rootprint = Rootprint::new("main", core.clone()).expect("valid root");
+    let left = rootprint
+        .fork("main", "candidate", attached.clone())
+        .expect("valid fork");
+    let right = rootprint
+        .fork("main", "audit", artifact("audit"))
+        .expect("valid fork");
+    rootprint
+        .merge(&left, &right, "accepted", artifact("accepted"))
+        .expect("valid merge");
+    rootprint.verify().expect("valid graph");
+
+    let core_bytes = write_json(&directory.join("core-valid.pha"), &core);
+    let attached_bytes = write_json(&directory.join("core-with-epa.pha"), &attached);
+    let rootprint_bytes = write_json(&directory.join("rootprint-valid.json"), &rootprint);
+    write_json(
+        Path::new("publicpower/artifacts/rootprint-valid.json"),
+        &rootprint,
+    );
+
+    let mut files = BTreeMap::new();
+    files.insert("core-valid.pha", sha256(&core_bytes));
+    files.insert("core-with-epa.pha", sha256(&attached_bytes));
+    files.insert("rootprint-valid.json", sha256(&rootprint_bytes));
+    let manifest: Value = json!({
+        "schema": "power-house-pha-conformance-v1",
+        "core_fingerprint": core.phx_fingerprint,
+        "external_attachments_affect_core_identity": false,
+        "files": files,
+        "mutation_rules": {
+            "core_field_mutation": "must fail core verification",
+            "epa_payload_mutation": "must preserve core verification and fail explicit EPA integrity verification"
+        }
+    });
+    write_json(&directory.join("manifest.json"), &manifest);
+}

--- a/examples/rootprint_benchmark.rs
+++ b/examples/rootprint_benchmark.rs
@@ -1,0 +1,130 @@
+use power_house::provenance::{PhaArtifact, Rootprint};
+use power_house::{Field, GeneralSumProof};
+use serde_json::json;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+fn micros(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000_000.0
+}
+
+fn artifact(index: usize) -> PhaArtifact {
+    PhaArtifact::new(
+        json!({"benchmark": "rootprint-v0.3.0", "index": index}),
+        "power-house/benchmark/v1",
+        json!({"index": index}),
+        json!({"accepted": true}),
+    )
+    .expect("valid benchmark artifact")
+}
+
+fn main() {
+    const CORE_ITERATIONS: usize = 10_000;
+    const BRANCHES: usize = 2_048;
+    const REPRODUCIBILITY_RUNS: usize = 1_000;
+
+    let field = Field::new(1_000_000_007);
+
+    let start = Instant::now();
+    let constant_proof = GeneralSumProof::prove_constant(70, &field, 173);
+    let constant_prove = start.elapsed();
+    let start = Instant::now();
+    assert!(constant_proof.verify_constant(&field, 173));
+    let constant_verify = start.elapsed();
+
+    let start = Instant::now();
+    let affine_proof =
+        GeneralSumProof::prove_seeded_affine(4_096, &field, b"power-house-v0.3.0-benchmark");
+    let affine_prove = start.elapsed();
+    let start = Instant::now();
+    assert!(affine_proof.verify_seeded_affine(&field, b"power-house-v0.3.0-benchmark"));
+    let affine_verify = start.elapsed();
+
+    let core = artifact(0);
+    let start = Instant::now();
+    for _ in 0..CORE_ITERATIONS {
+        black_box(core.calculate_phx_fingerprint().expect("fingerprint"));
+    }
+    let fingerprint_total = start.elapsed();
+    let start = Instant::now();
+    for _ in 0..CORE_ITERATIONS {
+        black_box(&core).verify().expect("core verification");
+    }
+    let core_verify_total = start.elapsed();
+
+    let mut graph = Rootprint::new("main", core.clone()).expect("rootprint");
+    let start = Instant::now();
+    for index in 1..=BRANCHES {
+        graph
+            .fork("main", format!("branch-{index}"), artifact(index))
+            .expect("fork");
+    }
+    let branch_build = start.elapsed();
+    let start = Instant::now();
+    graph.verify().expect("graph verification");
+    let graph_verify = start.elapsed();
+
+    let expected = core.phx_fingerprint.clone();
+    let start = Instant::now();
+    for _ in 0..REPRODUCIBILITY_RUNS {
+        assert_eq!(
+            core.calculate_phx_fingerprint().expect("fingerprint"),
+            expected
+        );
+    }
+    let reproducibility_total = start.elapsed();
+
+    let report = json!({
+        "schema": "power-house-benchmark-v0.3.0",
+        "release": "0.3.0",
+        "environment": {
+            "arch": std::env::consts::ARCH,
+            "os": std::env::consts::OS,
+            "profile": "release"
+        },
+        "scale": {
+            "constant": {
+                "domain": "2^70",
+                "domain_points": "1180591620717411303424",
+                "proof_rounds": constant_proof.claim.rounds.len(),
+                "prove_us": micros(constant_prove),
+                "verify_us": micros(constant_verify)
+            },
+            "seeded_affine": {
+                "domain": "2^4096",
+                "proof_rounds": affine_proof.claim.rounds.len(),
+                "prove_us": micros(affine_prove),
+                "verify_us": micros(affine_verify)
+            }
+        },
+        "provenance": {
+            "iterations": CORE_ITERATIONS,
+            "fingerprint_total_us": micros(fingerprint_total),
+            "fingerprint_mean_us": micros(fingerprint_total) / CORE_ITERATIONS as f64,
+            "verify_total_us": micros(core_verify_total),
+            "verify_mean_us": micros(core_verify_total) / CORE_ITERATIONS as f64
+        },
+        "branching": {
+            "branches": graph.branches.len(),
+            "fork_total_us": micros(branch_build),
+            "fork_mean_us": micros(branch_build) / BRANCHES as f64,
+            "full_graph_verify_us": micros(graph_verify)
+        },
+        "reproducibility": {
+            "runs": REPRODUCIBILITY_RUNS,
+            "identical_fingerprints": true,
+            "total_us": micros(reproducibility_total),
+            "phx_fingerprint": expected
+        },
+        "public_verification": {
+            "rust_conformance_vectors": 3,
+            "python_cross_language_vectors": 3,
+            "core_mutation_classes": 6,
+            "epa_mutation_isolated": true
+        }
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).expect("serialize report")
+    );
+}

--- a/examples/rootprint_workflow.rs
+++ b/examples/rootprint_workflow.rs
@@ -1,0 +1,40 @@
+use power_house::{prove_with_rootprint, provenance::PhaArtifact};
+use serde_json::json;
+
+fn artifact(stage: &str, accepted: bool) -> PhaArtifact {
+    PhaArtifact::new(
+        json!({"producer": "rootprint-workflow", "stage": stage}),
+        "power-house/example/v1",
+        json!({"stage": stage}),
+        json!({"accepted": accepted}),
+    )
+    .expect("valid artifact")
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut graph = prove_with_rootprint!(
+        label: "main",
+        artifact: artifact("baseline", true),
+    )?;
+    let candidate = prove_with_rootprint!(
+        rootprint: &mut graph,
+        fork: "main",
+        label: "candidate",
+        artifact: artifact("candidate", true),
+    )?;
+    let audit = prove_with_rootprint!(
+        rootprint: &mut graph,
+        fork: "main",
+        label: "audit",
+        artifact: artifact("audit", true),
+    )?;
+    prove_with_rootprint!(
+        rootprint: &mut graph,
+        merge: [&candidate, &audit],
+        label: "accepted",
+        artifact: artifact("accepted", true),
+    )?;
+    graph.verify()?;
+    println!("{}", serde_json::to_string_pretty(&graph)?);
+    Ok(())
+}

--- a/publicpower/app.css
+++ b/publicpower/app.css
@@ -1512,7 +1512,7 @@ body.proof-verified .proof-event b {
   }
 
   .proof-modes {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 
   .proof-mode {

--- a/publicpower/app.js
+++ b/publicpower/app.js
@@ -45,6 +45,29 @@ const iconLibrary = {
 };
 
 const modes = {
+  rootprint: {
+    exponent: 4,
+    domainLabel: "DAG<sup>4</sup>",
+    domainCaption: "PUBLIC STRUCTURE",
+    dossierDomain: "4-BRANCH DAG",
+    domain: "4 VERIFIED BRANCHES",
+    verifierPath: "CORE-ONLY DAG REPLAY",
+    allocation: "EPA STRICTLY OPTIONAL",
+    dossierArtifact: "ROOTPRINT v1 JSON",
+    kicker: "DETERMINISTIC PROVENANCE GRAPH",
+    description:
+      "Navigate, fork, merge, and verify proof history while optional external attachments remain outside core identity.",
+    title: "Verify the public provenance graph",
+    detail:
+      "The browser recalculates every PHA fingerprint and deterministic branch identifier.",
+    button: "VERIFY GRAPH",
+    status: "ROOTPRINT VERIFIER READY",
+    downloadHref: "artifacts/rootprint-valid.json",
+    downloadName: "rootprint-valid.json",
+    color: 0x45ddd2,
+    unit: "BRANCHES",
+    action: verifyRootprintRelease,
+  },
   constant: {
     exponent: 70,
     domain: "1.18 SEXTILLION POINTS",
@@ -124,6 +147,11 @@ const modes = {
 };
 
 const knownArtifacts = {
+  rootprint: {
+    size: 4_232,
+    hash: "eeb33450c6473c082675b8fcdaf70abfb0e6070fe739eeda5c839070d13750a3",
+    label: "ROOTPRINT v1",
+  },
   phsp: {
     size: 16_000_171,
     hash: "2b219ba189c3a38f1073c7797629e9aaf44a36820abb64c7628129480eb43f3b",
@@ -194,6 +222,7 @@ const el = Object.fromEntries(
     "evaluation-toggle",
     "evaluation-close",
     "domain-label",
+    "domain-caption",
     "domain-detail",
     "verifier-path",
     "allocation-value",
@@ -221,6 +250,7 @@ const el = Object.fromEntries(
     "mode-value",
     "status-seal",
     "seal-value",
+    "seal-unit",
     "toast",
     "sound-toggle",
     "motion-toggle",
@@ -232,7 +262,7 @@ const el = Object.fromEntries(
 el.canvas = el.orbitalCanvas;
 
 const state = {
-  mode: "constant",
+  mode: "rootprint",
   activeCity: 5,
   running: false,
   motion: !window.matchMedia("(prefers-reduced-motion: reduce)").matches,
@@ -1181,7 +1211,9 @@ function selectMode(name, withTone = true) {
     button.classList.toggle("active", active);
     button.setAttribute("aria-pressed", active ? "true" : "false");
   });
-  el.domainLabel.innerHTML = `2<sup>${mode.exponent.toLocaleString()}</sup>`;
+  el.domainLabel.innerHTML =
+    mode.domainLabel ?? `2<sup>${mode.exponent.toLocaleString()}</sup>`;
+  el.domainCaption.textContent = mode.domainCaption ?? "IMPLICIT DOMAIN";
   el.domainDetail.textContent = mode.domain;
   el.verifierPath.textContent = mode.verifierPath;
   el.allocationValue.textContent = mode.allocation;
@@ -1193,12 +1225,14 @@ function selectMode(name, withTone = true) {
   el.verifyButton.querySelector("span").textContent = mode.button;
   el.sealValue.textContent =
     mode.exponent >= 1_000_000 ? "1M" : mode.exponent.toLocaleString();
+  el.sealUnit.textContent = mode.unit ?? "ROUNDS";
   el.roundValue.textContent = `0 / ${mode.exponent.toLocaleString()}`;
   el.claimValue.textContent = "WAITING";
   el.digestValue.textContent = "PENDING";
   el.modeValue.textContent = name.toUpperCase();
   el.dossierMode.textContent = name.toUpperCase();
-  el.dossierDomain.textContent = `2^${mode.exponent.toLocaleString()}`;
+  el.dossierDomain.textContent =
+    mode.dossierDomain ?? `2^${mode.exponent.toLocaleString()}`;
   el.dossierWork.textContent = mode.verifierPath;
   el.dossierArtifact.textContent = mode.dossierArtifact;
   el.downloadButton.href = mode.downloadHref;
@@ -1239,6 +1273,123 @@ async function sha256Hex(value) {
   return [...new Uint8Array(digest)]
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function assertBrowserCanonicalNumbers(value) {
+  if (typeof value === "number" && !Number.isSafeInteger(value)) {
+    throw new Error("Browser verification requires safe integer JSON numbers");
+  }
+  if (Array.isArray(value)) {
+    value.forEach(assertBrowserCanonicalNumbers);
+  } else if (value && typeof value === "object") {
+    Object.values(value).forEach(assertBrowserCanonicalNumbers);
+  }
+}
+
+async function domainSeparatedHash(domain, value) {
+  const domainBytes = new TextEncoder().encode(`${domain}\0`);
+  const valueBytes = new TextEncoder().encode(canonicalJson(value));
+  const combined = new Uint8Array(domainBytes.length + valueBytes.length);
+  combined.set(domainBytes);
+  combined.set(valueBytes, domainBytes.length);
+  return `sha256:${await sha256Hex(combined)}`;
+}
+
+async function verifyPhaArtifact(artifact) {
+  if (artifact?.schema !== "power-house/pha/v1") {
+    throw new Error("Unsupported PHA schema");
+  }
+  const embedded = artifact.embedded_proof;
+  if (!embedded || typeof embedded.protocol !== "string" || !embedded.protocol.trim()) {
+    throw new Error("Invalid embedded Power House proof");
+  }
+  assertBrowserCanonicalNumbers(artifact.provenance);
+  assertBrowserCanonicalNumbers(embedded.public_inputs);
+  assertBrowserCanonicalNumbers(embedded.proof);
+  const core = {
+    embedded_proof: {
+      proof: embedded.proof,
+      protocol: embedded.protocol,
+      public_inputs: embedded.public_inputs,
+    },
+    provenance: artifact.provenance,
+    schema: artifact.schema,
+  };
+  const expected = await domainSeparatedHash(
+    "power-house:pha:v1:phx-fingerprint",
+    core,
+  );
+  if (artifact.phx_fingerprint !== expected) {
+    throw new Error("PHA core fingerprint mismatch");
+  }
+}
+
+async function verifyRootprintGraph(graph) {
+  if (graph?.schema !== "power-house/rootprint/v1") {
+    throw new Error("Unsupported Rootprint schema");
+  }
+  const branches = graph.branches;
+  const root = branches?.[graph.root_branch];
+  if (!root || root.sequence !== 0 || root.parents.length !== 0) {
+    throw new Error("Invalid Rootprint root branch");
+  }
+  const branchEntries = Object.entries(branches);
+  for (let index = 0; index < branchEntries.length; index += 1) {
+    const [key, branch] = branchEntries[index];
+    if (key !== branch.id) throw new Error("Rootprint branch key mismatch");
+    await verifyPhaArtifact(branch.artifact);
+    const parents = branch.parents;
+    if (
+      parents.length > 2 ||
+      parents.some((parent, parentIndex) => parentIndex > 0 && parents[parentIndex - 1] >= parent)
+    ) {
+      throw new Error("Rootprint parents are not sorted and unique");
+    }
+    if (branch.id !== graph.root_branch && parents.length === 0) {
+      throw new Error("Rootprint non-root branch has no parent");
+    }
+    for (const parentId of parents) {
+      const parent = branches[parentId];
+      if (!parent || parent.sequence >= branch.sequence) {
+        throw new Error("Rootprint parent ordering failed");
+      }
+    }
+    const expectedId = await domainSeparatedHash("power-house:rootprint:v1:branch-id", {
+      artifact_phx_fingerprint: branch.artifact.phx_fingerprint,
+      label: branch.label,
+      parents,
+    });
+    if (branch.id !== expectedId) throw new Error("Rootprint branch identifier mismatch");
+    el.roundValue.textContent = `${index + 1} / ${branchEntries.length}`;
+    setProgress(35 + ((index + 1) / branchEntries.length) * 55);
+  }
+
+  const reachable = new Set([graph.root_branch]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const branch of Object.values(branches)) {
+      if (!reachable.has(branch.id) && branch.parents.some((parent) => reachable.has(parent))) {
+        reachable.add(branch.id);
+        changed = true;
+      }
+    }
+  }
+  if (reachable.size !== branchEntries.length) {
+    throw new Error("Rootprint contains an unreachable branch");
+  }
+  return branchEntries.length;
 }
 
 function sleep(milliseconds) {
@@ -1474,6 +1625,32 @@ async function verifyReleaseArtifacts(kind) {
   }
 }
 
+async function verifyRootprintRelease() {
+  beginRun();
+  try {
+    el.verificationStatus.textContent = "DOWNLOADING ROOTPRINT v1";
+    const bytes = await fetchWithProgress(
+      "artifacts/rootprint-valid.json",
+      knownArtifacts.rootprint.size,
+      0,
+      28,
+    );
+    const digest = await sha256Hex(bytes);
+    if (digest !== knownArtifacts.rootprint.hash) {
+      throw new Error("Rootprint release SHA-256 mismatch");
+    }
+    el.verificationStatus.textContent = "REPLAYING CORE IDENTITIES";
+    const graph = JSON.parse(new TextDecoder().decode(bytes));
+    const branchCount = await verifyRootprintGraph(graph);
+    completeRun(digest, `${branchCount} BRANCHES OK`);
+    el.verificationTitle.textContent = "Rootprint graph and every PHA core accepted";
+    el.verificationDetail.textContent =
+      "EPA data was transported but deliberately excluded from all core identities.";
+  } catch (error) {
+    failRun(error.message);
+  }
+}
+
 function artifactType(file) {
   return file.name.toLowerCase().split(".").pop();
 }
@@ -1506,6 +1683,34 @@ async function readLocalFile(file, start, span) {
 async function verifyLocalArtifacts(fileList) {
   const files = [...fileList];
   const byType = new Map(files.map((file) => [artifactType(file), file]));
+  const portable = byType.get("json") ?? byType.get("pha");
+  if (portable) {
+    if (portable.size > 2_000_000) {
+      showToast("PHA and Rootprint JSON files must be 2 MB or smaller.");
+      return;
+    }
+    selectMode("rootprint");
+    beginRun();
+    try {
+      const bytes = new Uint8Array(await portable.arrayBuffer());
+      const value = JSON.parse(new TextDecoder().decode(bytes));
+      if (value.schema === "power-house/rootprint/v1") {
+        const branchCount = await verifyRootprintGraph(value);
+        completeRun(await sha256Hex(bytes), `${branchCount} BRANCHES OK`);
+      } else {
+        await verifyPhaArtifact(value);
+        completeRun(await sha256Hex(bytes), "PHA CORE OK");
+      }
+      el.verificationTitle.textContent = "Local Power House identity accepted";
+      el.verificationDetail.textContent =
+        "Verification used only Power House core fields; EPA remained optional.";
+    } catch (error) {
+      failRun(error.message);
+    } finally {
+      el.artifactInput.value = "";
+    }
+    return;
+  }
   const committed = byType.has("phsm") || byType.has("phcp");
   const required = committed ? ["phsm", "phcp"] : ["phsp"];
   const missing = required.filter((type) => !byType.has(type));
@@ -1547,8 +1752,8 @@ function scheduleAutoProof() {
   window.clearTimeout(autoProofTimer);
   autoProofTimer = window.setTimeout(() => {
     autoProofTimer = 0;
-    if (!state.userInteracted && !state.running && state.mode === "constant") {
-      runConstantProof();
+    if (!state.userInteracted && !state.running && state.mode === "rootprint") {
+      verifyRootprintRelease();
     }
   }, 2400);
 }
@@ -1727,7 +1932,7 @@ function init() {
   buildProofTrace();
   buildCityList();
   bindInterface();
-  selectMode("constant", false);
+  selectMode("rootprint", false);
   selectCity(state.activeCity, false);
   setMotion(state.motion);
   updateAstronomy();

--- a/publicpower/artifacts/rootprint-valid.json
+++ b/publicpower/artifacts/rootprint-valid.json
@@ -1,0 +1,128 @@
+{
+  "schema": "power-house/rootprint/v1",
+  "root_branch": "sha256:699a058e048208946b879ffe7b59d538f1e2586677585d3adb63e783d8480fd4",
+  "branches": {
+    "sha256:699a058e048208946b879ffe7b59d538f1e2586677585d3adb63e783d8480fd4": {
+      "id": "sha256:699a058e048208946b879ffe7b59d538f1e2586677585d3adb63e783d8480fd4",
+      "label": "main",
+      "sequence": 0,
+      "parents": [],
+      "artifact": {
+        "schema": "power-house/pha/v1",
+        "provenance": {
+          "producer": "power-house-conformance",
+          "stage": "baseline"
+        },
+        "embedded_proof": {
+          "protocol": "power-house/rootprint-example/v1",
+          "public_inputs": {
+            "claim": 70,
+            "field": 1000000007
+          },
+          "proof": {
+            "accepted": true,
+            "rounds": 70
+          }
+        },
+        "phx_fingerprint": "sha256:9cd9c336ffdabb701a907657c75d44e8fe5251fe951cc3cfc90ef228e29cacae"
+      }
+    },
+    "sha256:7741da3abefbe66fcd8bd547be0f5c16544154437b031b93a78da7266f38e4ba": {
+      "id": "sha256:7741da3abefbe66fcd8bd547be0f5c16544154437b031b93a78da7266f38e4ba",
+      "label": "audit",
+      "sequence": 1,
+      "parents": [
+        "sha256:699a058e048208946b879ffe7b59d538f1e2586677585d3adb63e783d8480fd4"
+      ],
+      "artifact": {
+        "schema": "power-house/pha/v1",
+        "provenance": {
+          "producer": "power-house-conformance",
+          "stage": "audit"
+        },
+        "embedded_proof": {
+          "protocol": "power-house/rootprint-example/v1",
+          "public_inputs": {
+            "claim": 70,
+            "field": 1000000007
+          },
+          "proof": {
+            "accepted": true,
+            "rounds": 70
+          }
+        },
+        "phx_fingerprint": "sha256:72f0bf01f23399c4bea1f0fc41b6a330a80dbf559c0c3184b9560b9e2cbe8a42"
+      }
+    },
+    "sha256:8ff2524d624945a81bc89934213b2652672f827bdd6fd32b5cce9be987231711": {
+      "id": "sha256:8ff2524d624945a81bc89934213b2652672f827bdd6fd32b5cce9be987231711",
+      "label": "accepted",
+      "sequence": 2,
+      "parents": [
+        "sha256:7741da3abefbe66fcd8bd547be0f5c16544154437b031b93a78da7266f38e4ba",
+        "sha256:f223e4ec43c132b0729dbf9b00ca32a639d00c00278bc71c5adc340d663e6a17"
+      ],
+      "artifact": {
+        "schema": "power-house/pha/v1",
+        "provenance": {
+          "producer": "power-house-conformance",
+          "stage": "accepted"
+        },
+        "embedded_proof": {
+          "protocol": "power-house/rootprint-example/v1",
+          "public_inputs": {
+            "claim": 70,
+            "field": 1000000007
+          },
+          "proof": {
+            "accepted": true,
+            "rounds": 70
+          }
+        },
+        "phx_fingerprint": "sha256:6e4f62bd1a2dce7961d8e88c0cbabba888ddc5e874be02d6fdf9c847e96c4966"
+      }
+    },
+    "sha256:f223e4ec43c132b0729dbf9b00ca32a639d00c00278bc71c5adc340d663e6a17": {
+      "id": "sha256:f223e4ec43c132b0729dbf9b00ca32a639d00c00278bc71c5adc340d663e6a17",
+      "label": "candidate",
+      "sequence": 1,
+      "parents": [
+        "sha256:699a058e048208946b879ffe7b59d538f1e2586677585d3adb63e783d8480fd4"
+      ],
+      "artifact": {
+        "schema": "power-house/pha/v1",
+        "provenance": {
+          "producer": "power-house-conformance",
+          "stage": "baseline"
+        },
+        "embedded_proof": {
+          "protocol": "power-house/rootprint-example/v1",
+          "public_inputs": {
+            "claim": 70,
+            "field": 1000000007
+          },
+          "proof": {
+            "accepted": true,
+            "rounds": 70
+          },
+          "external_proof_attachments": [
+            {
+              "id": "external-example-1",
+              "proof_system": "example/external-proof/v1",
+              "payload": {
+                "proof": "opaque-example",
+                "public_inputs": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "payload_sha256": "sha256:8188d0344f4a44aaa455ae4dd7e79d63e5793295b73ff24b79867eaf905281f4"
+            }
+          ]
+        },
+        "phx_fingerprint": "sha256:9cd9c336ffdabb701a907657c75d44e8fe5251fe951cc3cfc90ef228e29cacae"
+      }
+    }
+  }
+}

--- a/publicpower/index.html
+++ b/publicpower/index.html
@@ -4,11 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#010405">
-  <meta name="description" content="MFENX Power House: a live planetary instrument for reproducible large-domain proof verification.">
-  <meta property="og:title" content="MFENX Power House">
-  <meta property="og:description" content="Run public proofs across sextillion-scale and million-variable implicit domains.">
+  <meta name="description" content="MFENX Power House + Rootprint: public proof verification with deterministic provenance branching.">
+  <meta property="og:title" content="MFENX Power House + Rootprint">
+  <meta property="og:description" content="Verify public proofs and navigate deterministic provenance from one planetary instrument.">
   <meta property="og:image" content="https://mfenx.com/assets/proof-lattice.webp">
-  <title>MFENX Power House | Proof Singularity</title>
+  <title>MFENX Power House + Rootprint | Proof Observatory</title>
   <link rel="icon" href="assets/powerhouse-logo.png">
   <link rel="preload" href="assets/proof-lattice.webp" as="image">
   <link rel="preload" href="assets/earth-day.jpg" as="image" crossorigin="anonymous" media="(min-width: 761px)">
@@ -40,7 +40,7 @@
         <img src="assets/powerhouse-logo.png" alt="">
         <span>
           <strong>MFENX</strong>
-          <small>POWER HOUSE / PUBLIC PROOF INSTRUMENT</small>
+          <small>POWER HOUSE + ROOTPRINT / PUBLIC PROOF INSTRUMENT</small>
         </span>
       </a>
 
@@ -71,27 +71,32 @@
     <aside class="proof-rail" aria-label="Proof modes">
       <div class="rail-heading">
         <span>PUBLIC PROOF ARRAY</span>
-        <b>04</b>
+        <b>05</b>
       </div>
 
       <div id="proof-modes" class="proof-modes">
-        <button class="proof-mode active" data-mode="constant" type="button" aria-pressed="true">
+        <button class="proof-mode active" data-mode="rootprint" type="button" aria-pressed="true">
           <span class="mode-index">01</span>
+          <span class="mode-copy"><b>ROOTPRINT</b><small>PHA / CORE DAG</small></span>
+          <i></i>
+        </button>
+        <button class="proof-mode" data-mode="constant" type="button" aria-pressed="false">
+          <span class="mode-index">02</span>
           <span class="mode-copy"><b>SEXTILLION</b><small>70 ROUNDS</small></span>
           <i></i>
         </button>
         <button class="proof-mode" data-mode="affine" type="button" aria-pressed="false">
-          <span class="mode-index">02</span>
+          <span class="mode-index">03</span>
           <span class="mode-copy"><b>HYPERSCALE</b><small>4,096 ROUNDS</small></span>
           <i></i>
         </button>
         <button class="proof-mode" data-mode="sparse" type="button" aria-pressed="false">
-          <span class="mode-index">03</span>
+          <span class="mode-index">04</span>
           <span class="mode-copy"><b>MEGAROUND</b><small>PHSP / 1,000,000</small></span>
           <i></i>
         </button>
         <button class="proof-mode" data-mode="committed" type="button" aria-pressed="false">
-          <span class="mode-index">04</span>
+          <span class="mode-index">05</span>
           <span class="mode-copy"><b>COMMITTED</b><small>PHSM + PHCP</small></span>
           <i></i>
         </button>
@@ -114,17 +119,17 @@
       <div id="globe-tooltip" class="globe-tooltip" role="status"></div>
 
       <section class="proof-monument" aria-label="Selected proof scale">
-        <span id="orbit-kicker">CLOSED-FORM SUM-CHECK</span>
+        <span id="orbit-kicker">DETERMINISTIC PROVENANCE GRAPH</span>
         <h1>POWER HOUSE</h1>
         <div class="domain-equation">
-          <small>IMPLICIT DOMAIN</small>
-          <strong id="domain-label">2<sup>70</sup></strong>
+          <small id="domain-caption">PUBLIC STRUCTURE</small>
+          <strong id="domain-label">DAG<sup>4</sup></strong>
         </div>
-        <p id="orbit-description">Seventy verifier rounds close a domain larger than one sextillion Boolean points without enumerating it.</p>
+        <p id="orbit-description">Navigate, fork, merge, and verify proof history while optional external attachments remain outside core identity.</p>
         <div class="mode-metrics">
-          <div><span>PUBLIC SCALE</span><b id="domain-detail">1.18 SEXTILLION POINTS</b></div>
-          <div><span>VERIFIER PATH</span><b id="verifier-path">70 FIELD EQUATIONS</b></div>
-          <div><span>EXPANDED DOMAIN</span><b id="allocation-value">NEVER ALLOCATED</b></div>
+          <div><span>PUBLIC SCALE</span><b id="domain-detail">4 VERIFIED BRANCHES</b></div>
+          <div><span>VERIFIER PATH</span><b id="verifier-path">CORE-ONLY DAG REPLAY</b></div>
+          <div><span>EXTERNAL PROOFS</span><b id="allocation-value">STRICTLY OPTIONAL</b></div>
         </div>
       </section>
 
@@ -215,10 +220,10 @@
       </div>
 
       <dl class="evaluation-spec">
-        <div><dt>SELECTED ARRAY</dt><dd id="dossier-mode">SEXTILLION</dd></div>
-        <div><dt>DOMAIN</dt><dd id="dossier-domain">2^70</dd></div>
-        <div><dt>VERIFIER WORK</dt><dd id="dossier-work">70 ROUNDS</dd></div>
-        <div><dt>PUBLIC ARTIFACT</dt><dd id="dossier-artifact">BROWSER TRACE</dd></div>
+        <div><dt>SELECTED ARRAY</dt><dd id="dossier-mode">ROOTPRINT</dd></div>
+        <div><dt>DOMAIN</dt><dd id="dossier-domain">4-BRANCH DAG</dd></div>
+        <div><dt>VERIFIER WORK</dt><dd id="dossier-work">CORE-ONLY DAG REPLAY</dd></div>
+        <div><dt>PUBLIC ARTIFACT</dt><dd id="dossier-artifact">ROOTPRINT v1 JSON</dd></div>
       </dl>
 
       <a class="evaluation-primary" href="https://github.com/JROChub/power_house/issues/new?template=technical-evaluation.yml">
@@ -228,15 +233,15 @@
       <div class="evaluation-links">
         <a href="https://github.com/JROChub/power_house/blob/main/docs/verification_guide.md">REPRODUCE</a>
         <a href="https://github.com/JROChub/power_house/blob/main/docs/security_model.md">SECURITY MODEL</a>
-        <a href="https://crates.io/crates/power_house">CRATE v0.2.2</a>
+        <a href="https://crates.io/crates/power_house">CRATE v0.3.0</a>
       </div>
     </aside>
 
     <section class="verification-dock" aria-label="Verification console">
       <div class="trace-header">
-        <span id="verification-status">LOCAL VERIFIER READY</span>
-        <b id="verification-title">Run the 70-round browser proof</b>
-        <p id="verification-detail">Every round equation is checked over the field before the certificate digest is accepted.</p>
+        <span id="verification-status">ROOTPRINT VERIFIER READY</span>
+        <b id="verification-title">Verify the public provenance graph</b>
+        <p id="verification-detail">The browser recalculates every PHA fingerprint and deterministic branch identifier.</p>
       </div>
 
       <div class="trace-runway">
@@ -245,31 +250,31 @@
       </div>
 
       <div class="verification-actions">
-        <input id="artifact-input" type="file" multiple hidden accept=".phsp,.phsm,.phcp">
+        <input id="artifact-input" type="file" multiple hidden accept=".pha,.json,.phsp,.phsm,.phcp">
         <button id="artifact-button" class="artifact-button" type="button" title="Verify local artifact files">
           <span data-icon="upload"></span><b>LOCAL FILE</b>
         </button>
-        <a id="download-button" class="download-button" href="artifacts/power_house_sparse_record.phsp" download title="Download selected public artifact">
+        <a id="download-button" class="download-button" href="artifacts/rootprint-valid.json" download title="Download selected public artifact">
           <span data-icon="download"></span>
         </a>
         <button id="share-button" class="share-button" type="button" disabled title="Share verification result">
           <span data-icon="share-2"></span>
         </button>
         <button id="verify-button" class="verify-button" type="button">
-          <span>RUN PROOF</span>
+          <span>VERIFY GRAPH</span>
           <b>ENTER</b>
         </button>
       </div>
 
       <div class="telemetry">
         <div class="status-seal" id="status-seal">
-          <span>READY</span><b id="seal-value">70</b><small>ROUNDS</small>
+          <span>READY</span><b id="seal-value">4</b><small id="seal-unit">BRANCHES</small>
         </div>
-        <div><span>ROUND</span><b id="round-value">0 / 70</b></div>
+        <div><span>ROUND</span><b id="round-value">0 / 4</b></div>
         <div><span>CLAIM</span><b id="claim-value">WAITING</b></div>
         <div><span>DIGEST</span><b id="digest-value">PENDING</b></div>
-        <div><span>MODE</span><b id="mode-value">CONSTANT</b></div>
-        <div><span>RELEASE</span><b>v0.2.2</b></div>
+        <div><span>MODE</span><b id="mode-value">ROOTPRINT</b></div>
+        <div><span>RELEASE</span><b>v0.3.0</b></div>
       </div>
     </section>
 

--- a/scripts/benchmark_v030.py
+++ b/scripts/benchmark_v030.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Run and publish the reproducible Power House v0.3.0 benchmark report."""
+
+import json
+import pathlib
+import subprocess
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+OUTPUT = ROOT / "benchmarks" / "v0.3.0" / "report.json"
+
+
+def main() -> None:
+    completed = subprocess.run(
+        ["cargo", "run", "--release", "--example", "rootprint_benchmark"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    report = json.loads(completed.stdout)
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(OUTPUT.relative_to(ROOT))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_cli.sh
+++ b/scripts/test_cli.sh
@@ -23,6 +23,8 @@ expect_output() {
 
 expect_output "Power-House JULIAN" --help
 expect_output "julian $VERSION" --version
+expect_output "navigate" rootprint --help
+expect_output "never changes the Power House core fingerprint" attach-external-proof --help
 expect_output "verify-proof" node --help
 expect_output "streaming sum-check" scale_sumcheck --help
 expect_output "verify-envelope" net --help

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,23 @@
+# Power House Python SDK
+
+The default `power_house` namespace implements `.pha` v1 and Rootprint v1
+without requiring or interpreting external proof attachments.
+
+```python
+from power_house import create_artifact, new_rootprint, verify_rootprint
+
+artifact = create_artifact(
+    provenance={"source": "python"},
+    protocol="power-house/example/v1",
+    public_inputs={"claim": 7},
+    proof={"accepted": True},
+)
+graph = new_rootprint("main", artifact)
+verify_rootprint(graph)
+```
+
+EPA transport helpers are deliberately separated:
+
+```python
+from power_house.external import attach_external_proof, verify_external_attachments
+```

--- a/sdk/python/power_house/__init__.py
+++ b/sdk/python/power_house/__init__.py
@@ -1,0 +1,37 @@
+"""Power House Archive and Rootprint v1 core SDK.
+
+External proof attachments are intentionally absent from this namespace.
+Import ``power_house.external`` explicitly when attachment transport is needed.
+"""
+
+from .core import (
+    PHA_SCHEMA_V1,
+    ROOTPRINT_SCHEMA_V1,
+    PowerHouseError,
+    calculate_phx_fingerprint,
+    create_artifact,
+    equivalent,
+    fork,
+    merge,
+    navigate,
+    new_rootprint,
+    verify_artifact,
+    verify_rootprint,
+)
+
+__all__ = [
+    "PHA_SCHEMA_V1",
+    "ROOTPRINT_SCHEMA_V1",
+    "PowerHouseError",
+    "calculate_phx_fingerprint",
+    "create_artifact",
+    "equivalent",
+    "fork",
+    "merge",
+    "navigate",
+    "new_rootprint",
+    "verify_artifact",
+    "verify_rootprint",
+]
+
+__version__ = "0.3.0"

--- a/sdk/python/power_house/core.py
+++ b/sdk/python/power_house/core.py
@@ -1,0 +1,275 @@
+"""Pure Power House `.pha` and Rootprint operations."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import unicodedata
+from typing import Any, Dict, Iterable, List
+
+PHA_SCHEMA_V1 = "power-house/pha/v1"
+ROOTPRINT_SCHEMA_V1 = "power-house/rootprint/v1"
+
+_PHX_DOMAIN = b"power-house:pha:v1:phx-fingerprint\x00"
+_BRANCH_DOMAIN = b"power-house:rootprint:v1:branch-id\x00"
+
+
+class PowerHouseError(ValueError):
+    """Raised when a Power House artifact or Rootprint graph is invalid."""
+
+
+def _canonical_json(value: Any) -> bytes:
+    _validate_json_numbers(value)
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _validate_json_numbers(value: Any) -> None:
+    if isinstance(value, bool) or value is None or isinstance(value, str):
+        return
+    if isinstance(value, int):
+        if value < -(2**63) or value > 2**64 - 1:
+            raise PowerHouseError("JSON integer is outside the Rust i64/u64 range")
+        return
+    if isinstance(value, float):
+        raise PowerHouseError("non-integer JSON numbers are not canonical")
+    if isinstance(value, list):
+        for item in value:
+            _validate_json_numbers(item)
+        return
+    if isinstance(value, dict):
+        for item in value.values():
+            _validate_json_numbers(item)
+        return
+    raise PowerHouseError(f"value is not JSON-compatible: {type(value).__name__}")
+
+
+def _sha256(domain: bytes, value: Any) -> str:
+    digest = hashlib.sha256(domain + _canonical_json(value)).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _core_projection(artifact: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        embedded = artifact["embedded_proof"]
+        return {
+            "embedded_proof": {
+                "proof": embedded["proof"],
+                "protocol": embedded["protocol"],
+                "public_inputs": embedded["public_inputs"],
+            },
+            "provenance": artifact["provenance"],
+            "schema": artifact["schema"],
+        }
+    except (KeyError, TypeError) as error:
+        raise PowerHouseError(f"invalid PHA structure: {error}") from error
+
+
+def calculate_phx_fingerprint(artifact: Dict[str, Any]) -> str:
+    """Calculate core identity while ignoring EPA and stored fingerprint."""
+    return _sha256(_PHX_DOMAIN, _core_projection(artifact))
+
+
+def create_artifact(
+    provenance: Any,
+    protocol: str,
+    public_inputs: Any,
+    proof: Any,
+) -> Dict[str, Any]:
+    """Create a pure Power House `.pha` v1 artifact."""
+    if not isinstance(protocol, str) or not protocol.strip():
+        raise PowerHouseError("embedded proof protocol must not be empty")
+    artifact = {
+        "schema": PHA_SCHEMA_V1,
+        "provenance": copy.deepcopy(provenance),
+        "embedded_proof": {
+            "protocol": protocol,
+            "public_inputs": copy.deepcopy(public_inputs),
+            "proof": copy.deepcopy(proof),
+        },
+        "phx_fingerprint": "",
+    }
+    artifact["phx_fingerprint"] = calculate_phx_fingerprint(artifact)
+    return artifact
+
+
+def verify_artifact(artifact: Dict[str, Any]) -> None:
+    """Verify only Power House core data."""
+    if artifact.get("schema") != PHA_SCHEMA_V1:
+        raise PowerHouseError(f"unsupported PHA schema: {artifact.get('schema')}")
+    protocol = artifact.get("embedded_proof", {}).get("protocol")
+    if not isinstance(protocol, str) or not protocol.strip():
+        raise PowerHouseError("embedded proof protocol must not be empty")
+    found = artifact.get("phx_fingerprint")
+    expected = calculate_phx_fingerprint(artifact)
+    if found != expected:
+        raise PowerHouseError(
+            f"PHA core fingerprint mismatch: expected {expected}, found {found}"
+        )
+
+
+def _branch_id(label: str, parents: Iterable[str], artifact: Dict[str, Any]) -> str:
+    verify_artifact(artifact)
+    return _sha256(
+        _BRANCH_DOMAIN,
+        {
+            "artifact_phx_fingerprint": artifact["phx_fingerprint"],
+            "label": label,
+            "parents": list(parents),
+        },
+    )
+
+
+def _normalize_label(label: str) -> str:
+    if (
+        not isinstance(label, str)
+        or not label.strip()
+        or len(label.strip()) > 128
+        or any(unicodedata.category(character) == "Cc" for character in label)
+    ):
+        raise PowerHouseError(f"invalid branch label: {label!r}")
+    return label.strip()
+
+
+def new_rootprint(label: str, artifact: Dict[str, Any]) -> Dict[str, Any]:
+    """Create a Rootprint graph from a verified artifact."""
+    label = _normalize_label(label)
+    artifact = copy.deepcopy(artifact)
+    branch_id = _branch_id(label, [], artifact)
+    return {
+        "schema": ROOTPRINT_SCHEMA_V1,
+        "root_branch": branch_id,
+        "branches": {
+            branch_id: {
+                "id": branch_id,
+                "label": label,
+                "sequence": 0,
+                "parents": [],
+                "artifact": artifact,
+            }
+        },
+    }
+
+
+def navigate(graph: Dict[str, Any], selector: str) -> Dict[str, Any]:
+    """Resolve an exact ID, unique ID prefix, or unique label."""
+    branches = graph.get("branches", {})
+    if selector in branches:
+        return branches[selector]
+    matches = [
+        branch
+        for branch in branches.values()
+        if branch.get("id", "").startswith(selector) or branch.get("label") == selector
+    ]
+    if not matches:
+        raise PowerHouseError(f"branch not found: {selector}")
+    if len(matches) != 1:
+        raise PowerHouseError(f"ambiguous branch selector: {selector}")
+    return matches[0]
+
+
+def fork(
+    graph: Dict[str, Any],
+    parent: str,
+    label: str,
+    artifact: Dict[str, Any],
+) -> str:
+    """Append a one-parent branch and return its deterministic ID."""
+    parent_branch = navigate(graph, parent)
+    label = _normalize_label(label)
+    artifact = copy.deepcopy(artifact)
+    parents = [parent_branch["id"]]
+    branch_id = _branch_id(label, parents, artifact)
+    if branch_id in graph["branches"]:
+        raise PowerHouseError(f"branch already exists: {branch_id}")
+    graph["branches"][branch_id] = {
+        "id": branch_id,
+        "label": label,
+        "sequence": parent_branch["sequence"] + 1,
+        "parents": parents,
+        "artifact": artifact,
+    }
+    return branch_id
+
+
+def merge(
+    graph: Dict[str, Any],
+    left: str,
+    right: str,
+    label: str,
+    artifact: Dict[str, Any],
+) -> str:
+    """Append a two-parent merge branch and return its deterministic ID."""
+    left_branch = navigate(graph, left)
+    right_branch = navigate(graph, right)
+    if left_branch["id"] == right_branch["id"]:
+        raise PowerHouseError("merge parents resolve to the same branch")
+    label = _normalize_label(label)
+    artifact = copy.deepcopy(artifact)
+    parents = sorted([left_branch["id"], right_branch["id"]])
+    branch_id = _branch_id(label, parents, artifact)
+    if branch_id in graph["branches"]:
+        raise PowerHouseError(f"branch already exists: {branch_id}")
+    graph["branches"][branch_id] = {
+        "id": branch_id,
+        "label": label,
+        "sequence": max(left_branch["sequence"], right_branch["sequence"]) + 1,
+        "parents": parents,
+        "artifact": artifact,
+    }
+    return branch_id
+
+
+def equivalent(graph: Dict[str, Any], left: str, right: str) -> bool:
+    """Compare branch core identities while ignoring EPA."""
+    return (
+        navigate(graph, left)["artifact"]["phx_fingerprint"]
+        == navigate(graph, right)["artifact"]["phx_fingerprint"]
+    )
+
+
+def verify_rootprint(graph: Dict[str, Any]) -> None:
+    """Verify Rootprint graph invariants using Power House core data only."""
+    if graph.get("schema") != ROOTPRINT_SCHEMA_V1:
+        raise PowerHouseError(f"unsupported Rootprint schema: {graph.get('schema')}")
+    branches = graph.get("branches")
+    root_id = graph.get("root_branch")
+    if not isinstance(branches, dict) or root_id not in branches:
+        raise PowerHouseError("Rootprint root branch is missing")
+    root = branches[root_id]
+    if root.get("sequence") != 0 or root.get("parents") != []:
+        raise PowerHouseError("root branch must have sequence 0 and no parents")
+
+    for key, branch in branches.items():
+        if key != branch.get("id"):
+            raise PowerHouseError("branch map key does not match branch id")
+        verify_artifact(branch["artifact"])
+        parents: List[str] = branch.get("parents", [])
+        if branch["id"] != _branch_id(branch["label"], parents, branch["artifact"]):
+            raise PowerHouseError("Rootprint branch ID mismatch")
+        if len(parents) > 2 or parents != sorted(set(parents)):
+            raise PowerHouseError("branch parents must be sorted and unique")
+        if key != root_id and not parents:
+            raise PowerHouseError("non-root branch has no parent")
+        for parent_id in parents:
+            parent = branches.get(parent_id)
+            if parent is None or parent["sequence"] >= branch["sequence"]:
+                raise PowerHouseError("branch does not follow its parent")
+
+    reachable = {root_id}
+    while True:
+        expanded = reachable | {
+            branch_id
+            for branch_id, branch in branches.items()
+            if any(parent in reachable for parent in branch["parents"])
+        }
+        if expanded == reachable:
+            break
+        reachable = expanded
+    if reachable != set(branches):
+        raise PowerHouseError("graph contains a branch unreachable from the root")

--- a/sdk/python/power_house/external.py
+++ b/sdk/python/power_house/external.py
@@ -1,0 +1,66 @@
+"""Explicit, optional external proof attachment transport helpers."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any, Dict, Optional
+
+from .core import PowerHouseError, _validate_json_numbers, verify_artifact
+
+
+def _payload_digest(payload: Any) -> str:
+    _validate_json_numbers(payload)
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def attach_external_proof(
+    artifact: Dict[str, Any],
+    attachment_id: str,
+    proof_system: str,
+    payload: Any,
+    *,
+    verifier_hint: Optional[str] = None,
+    metadata: Any = None,
+) -> Dict[str, Any]:
+    """Return a copy with EPA data; core identity remains unchanged."""
+    verify_artifact(artifact)
+    if not attachment_id.strip() or not proof_system.strip():
+        raise PowerHouseError("attachment id and proof system must not be empty")
+    updated = copy.deepcopy(artifact)
+    attachment = {
+        "id": attachment_id,
+        "proof_system": proof_system,
+        "payload": copy.deepcopy(payload),
+        "payload_sha256": _payload_digest(payload),
+    }
+    if verifier_hint is not None:
+        attachment["verifier_hint"] = verifier_hint
+    if metadata is not None:
+        attachment["metadata"] = copy.deepcopy(metadata)
+    embedded = updated["embedded_proof"]
+    embedded.setdefault("external_proof_attachments", []).append(attachment)
+    return updated
+
+
+def verify_external_attachments(artifact: Dict[str, Any]) -> None:
+    """Verify EPA transport integrity after verifying Power House core data."""
+    verify_artifact(artifact)
+    attachments = artifact["embedded_proof"].get("external_proof_attachments", [])
+    for attachment in attachments:
+        if not attachment.get("id", "").strip():
+            raise PowerHouseError("attachment id must not be empty")
+        if not attachment.get("proof_system", "").strip():
+            raise PowerHouseError("attachment proof system must not be empty")
+        expected = _payload_digest(attachment.get("payload"))
+        if attachment.get("payload_sha256") != expected:
+            raise PowerHouseError(
+                f"external proof attachment {attachment.get('id')} digest mismatch"
+            )

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "power-house-sdk"
+version = "0.3.0"
+description = "Zero-dependency Python SDK for Power House Archive and Rootprint v1"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT OR BSD-2-Clause" }
+authors = [{ name = "MFENX LLC" }]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["power_house*"]

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -1,0 +1,89 @@
+import copy
+import json
+import pathlib
+import unittest
+
+from power_house import (
+    PowerHouseError,
+    calculate_phx_fingerprint,
+    create_artifact,
+    equivalent,
+    fork,
+    merge,
+    new_rootprint,
+    verify_artifact,
+    verify_rootprint,
+)
+from power_house.external import attach_external_proof, verify_external_attachments
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+VECTORS = ROOT / "conformance" / "pha-v1"
+
+
+class PowerHouseSdkTests(unittest.TestCase):
+    def test_core_defaults_and_optional_epa_are_separate(self):
+        artifact = create_artifact(
+            {"source": "python"},
+            "power-house/test/v1",
+            {"claim": 7},
+            {"accepted": True},
+        )
+        self.assertNotIn(
+            "external_proof_attachments", artifact["embedded_proof"]
+        )
+        attached = attach_external_proof(
+            artifact, "epa-1", "external/test/v1", {"proof": "opaque"}
+        )
+        self.assertEqual(
+            artifact["phx_fingerprint"], attached["phx_fingerprint"]
+        )
+        verify_artifact(attached)
+        verify_external_attachments(attached)
+
+        attached["embedded_proof"]["external_proof_attachments"][0][
+            "payload"
+        ] = {"proof": "mutated"}
+        verify_artifact(attached)
+        with self.assertRaises(PowerHouseError):
+            verify_external_attachments(attached)
+
+    def test_rootprint_branching_ignores_epa(self):
+        base = create_artifact({}, "power-house/test/v1", {}, {"value": 1})
+        graph = new_rootprint("main", base)
+        attached = attach_external_proof(
+            base, "epa-1", "external/test/v1", {"proof": "opaque"}
+        )
+        left = fork(graph, "main", "left", attached)
+        right = fork(graph, "main", "right", base)
+        merge(graph, left, right, "merged", base)
+        self.assertTrue(equivalent(graph, left, right))
+        verify_rootprint(graph)
+
+    def test_non_integer_numbers_are_rejected(self):
+        with self.assertRaises(PowerHouseError):
+            create_artifact({}, "power-house/test/v1", {}, {"value": 1.5})
+
+    def test_rust_conformance_vectors(self):
+        core = json.loads((VECTORS / "core-valid.pha").read_text())
+        attached = json.loads((VECTORS / "core-with-epa.pha").read_text())
+        graph = json.loads((VECTORS / "rootprint-valid.json").read_text())
+        verify_artifact(core)
+        verify_artifact(attached)
+        verify_external_attachments(attached)
+        verify_rootprint(graph)
+        self.assertEqual(
+            core["phx_fingerprint"], calculate_phx_fingerprint(core)
+        )
+        self.assertEqual(
+            core["phx_fingerprint"], attached["phx_fingerprint"]
+        )
+
+        broken = copy.deepcopy(core)
+        broken["embedded_proof"]["proof"]["accepted"] = False
+        with self.assertRaises(PowerHouseError):
+            verify_artifact(broken)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/bin/julian.rs
+++ b/src/bin/julian.rs
@@ -21,6 +21,7 @@ use power_house::net::{
     AnchorEnvelope, AnchorJson, Ed25519KeySource, MembershipPolicy, MultisigPolicy, NamespaceRule,
     NetConfig, StakePolicy, StakeRegistry, StaticPolicy,
 };
+use power_house::provenance::{ExternalProofAttachment, PhaArtifact, Rootprint};
 use power_house::{
     compute_fold_digest, julian_genesis_anchor, parse_log_file, read_fold_digest_hint,
     reconcile_anchors_with_quorum, AnchorMetadata, AnchorVote, EntryAnchor, Field, GeneralSumProof,
@@ -61,8 +62,12 @@ fn print_cli_help() {
     println!("Usage: julian <command> [options]");
     println!();
     println!("Core commands:");
+    println!("  rootprint        Navigate, fork, merge, and verify Power House provenance");
     println!("  node             Replay logs, derive anchors, and verify Merkle proofs");
     println!("  scale_sumcheck   Benchmark streaming sum-check verification");
+    println!();
+    println!("Optional external integration:");
+    println!("  attach-external-proof  Attach non-core proof data to a .pha artifact");
     #[cfg(feature = "net")]
     {
         println!();
@@ -91,6 +96,32 @@ fn print_node_help() {
 fn print_scale_help() {
     println!("Usage: julian scale_sumcheck [--vars <N>]");
     println!("  Runs deterministic streaming sum-check benchmarks through N variables.");
+}
+
+fn print_rootprint_help() {
+    println!("Usage: julian rootprint <init|navigate|fork|merge|verify|equivalent> ...");
+    println!("  init <artifact.pha> --label <name> --output <rootprint.json>");
+    println!("  navigate <rootprint.json> <branch-selector> [--artifact-output <file>]");
+    println!("  fork <rootprint.json> <parent> <artifact.pha> --label <name> [--output <file>]");
+    println!(
+        "  merge <rootprint.json> <left> <right> <artifact.pha> --label <name> [--output <file>]"
+    );
+    println!("  verify <rootprint.json>");
+    println!("  equivalent <rootprint.json> <left> <right>");
+    println!();
+    println!("Rootprint commands verify Power House core data only.");
+}
+
+fn print_attach_external_proof_help() {
+    println!("Usage: julian attach-external-proof <artifact.pha> [options]");
+    println!("  --id <id>                 Attachment identifier");
+    println!("  --proof-system <name>     External proof system identifier");
+    println!("  --payload <json-file>     Opaque external proof payload");
+    println!("  --verifier-hint <value>   Optional verifier hint");
+    println!("  --metadata <json-file>    Optional non-core metadata");
+    println!("  --output <artifact.pha>   Output path; defaults to the input artifact");
+    println!();
+    println!("This optional command never changes the Power House core fingerprint.");
 }
 
 #[cfg(feature = "net")]
@@ -241,6 +272,16 @@ fn main() {
         Some("scale_sumcheck") => {
             cmd_scale_sumcheck(args.collect());
         }
+        Some("rootprint") => {
+            if let Some(sub) = args.next() {
+                handle_rootprint(&sub, args.collect());
+            } else {
+                print_rootprint_help();
+            }
+        }
+        Some("attach-external-proof") => {
+            cmd_attach_external_proof(args.collect());
+        }
         #[cfg(feature = "net")]
         Some("keygen") => {
             cmd_keygen(args.collect());
@@ -295,6 +336,300 @@ fn main() {
             std::process::exit(1);
         }
     }
+}
+
+fn handle_rootprint(sub: &str, tail: Vec<String>) {
+    match sub {
+        "-h" | "--help" => print_rootprint_help(),
+        "init" => cmd_rootprint_init(tail),
+        "navigate" => cmd_rootprint_navigate(tail),
+        "fork" => cmd_rootprint_fork(tail),
+        "merge" => cmd_rootprint_merge(tail),
+        "verify" => cmd_rootprint_verify(tail),
+        "equivalent" => cmd_rootprint_equivalent(tail),
+        _ => fatal(&format!("unknown rootprint subcommand: {sub}")),
+    }
+}
+
+fn read_pha(path: &Path) -> PhaArtifact {
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|err| fatal(&format!("failed to read {}: {err}", path.display())));
+    serde_json::from_str(&contents)
+        .unwrap_or_else(|err| fatal(&format!("invalid .pha JSON in {}: {err}", path.display())))
+}
+
+fn read_rootprint(path: &Path) -> Rootprint {
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|err| fatal(&format!("failed to read {}: {err}", path.display())));
+    serde_json::from_str(&contents).unwrap_or_else(|err| {
+        fatal(&format!(
+            "invalid Rootprint JSON in {}: {err}",
+            path.display()
+        ))
+    })
+}
+
+fn read_json_value(path: &Path) -> serde_json::Value {
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|err| fatal(&format!("failed to read {}: {err}", path.display())));
+    serde_json::from_str(&contents)
+        .unwrap_or_else(|err| fatal(&format!("invalid JSON in {}: {err}", path.display())))
+}
+
+fn write_json<T: serde::Serialize>(path: &Path, value: &T) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|err| {
+            fatal(&format!(
+                "failed to create output directory {}: {err}",
+                parent.display()
+            ))
+        });
+    }
+    let mut bytes = serde_json::to_vec_pretty(value)
+        .unwrap_or_else(|err| fatal(&format!("failed to encode JSON: {err}")));
+    bytes.push(b'\n');
+    fs::write(path, bytes)
+        .unwrap_or_else(|err| fatal(&format!("failed to write {}: {err}", path.display())));
+}
+
+fn take_option(iter: &mut impl Iterator<Item = String>, name: &str) -> String {
+    iter.next()
+        .unwrap_or_else(|| fatal(&format!("{name} expects a value")))
+}
+
+fn cmd_rootprint_init(args: Vec<String>) {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_rootprint_help();
+        return;
+    }
+    let mut artifact_path = None;
+    let mut label = None;
+    let mut output = None;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--label" => label = Some(take_option(&mut iter, "--label")),
+            "--output" => output = Some(PathBuf::from(take_option(&mut iter, "--output"))),
+            value if artifact_path.is_none() => artifact_path = Some(PathBuf::from(value)),
+            other => fatal(&format!("unknown argument: {other}")),
+        }
+    }
+    let artifact_path = artifact_path.unwrap_or_else(|| fatal("artifact.pha is required"));
+    let output = output.unwrap_or_else(|| fatal("--output is required"));
+    let label = label.unwrap_or_else(|| fatal("--label is required"));
+    let artifact = read_pha(&artifact_path);
+    let graph = Rootprint::new(label, artifact)
+        .unwrap_or_else(|err| fatal(&format!("failed to create Rootprint: {err}")));
+    write_json(&output, &graph);
+    println!("root_branch: {}", graph.root_branch);
+    println!("rootprint: {}", output.display());
+}
+
+fn cmd_rootprint_navigate(args: Vec<String>) {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_rootprint_help();
+        return;
+    }
+    let mut positionals = Vec::new();
+    let mut artifact_output = None;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--artifact-output" => {
+                artifact_output = Some(PathBuf::from(take_option(&mut iter, "--artifact-output")))
+            }
+            value if !value.starts_with("--") => positionals.push(value.to_string()),
+            other => fatal(&format!("unknown argument: {other}")),
+        }
+    }
+    if positionals.len() != 2 {
+        fatal("navigate requires <rootprint.json> <branch-selector>");
+    }
+    let graph = read_rootprint(Path::new(&positionals[0]));
+    graph
+        .verify()
+        .unwrap_or_else(|err| fatal(&format!("Rootprint verification failed: {err}")));
+    let branch = graph
+        .navigate(&positionals[1])
+        .unwrap_or_else(|err| fatal(&err.to_string()));
+    if let Some(path) = artifact_output {
+        write_json(&path, &branch.artifact);
+    }
+    println!(
+        "{}",
+        serde_json::to_string_pretty(branch)
+            .unwrap_or_else(|err| fatal(&format!("failed to encode branch: {err}")))
+    );
+}
+
+fn cmd_rootprint_fork(args: Vec<String>) {
+    mutate_rootprint(args, false);
+}
+
+fn cmd_rootprint_merge(args: Vec<String>) {
+    mutate_rootprint(args, true);
+}
+
+fn mutate_rootprint(args: Vec<String>, merge: bool) {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_rootprint_help();
+        return;
+    }
+    let required = if merge { 4 } else { 3 };
+    let mut positionals = Vec::new();
+    let mut label = None;
+    let mut output = None;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--label" => label = Some(take_option(&mut iter, "--label")),
+            "--output" => output = Some(PathBuf::from(take_option(&mut iter, "--output"))),
+            value if !value.starts_with("--") => positionals.push(value.to_string()),
+            other => fatal(&format!("unknown argument: {other}")),
+        }
+    }
+    if positionals.len() != required {
+        if merge {
+            fatal("merge requires <rootprint.json> <left> <right> <artifact.pha>");
+        }
+        fatal("fork requires <rootprint.json> <parent> <artifact.pha>");
+    }
+    let input = PathBuf::from(&positionals[0]);
+    let output = output.unwrap_or_else(|| input.clone());
+    let label = label.unwrap_or_else(|| fatal("--label is required"));
+    let mut graph = read_rootprint(&input);
+    graph
+        .verify()
+        .unwrap_or_else(|err| fatal(&format!("Rootprint verification failed: {err}")));
+    let artifact_path = if merge {
+        &positionals[3]
+    } else {
+        &positionals[2]
+    };
+    let artifact = read_pha(Path::new(artifact_path));
+    let branch_id = if merge {
+        graph
+            .merge(&positionals[1], &positionals[2], label, artifact)
+            .unwrap_or_else(|err| fatal(&format!("merge failed: {err}")))
+    } else {
+        graph
+            .fork(&positionals[1], label, artifact)
+            .unwrap_or_else(|err| fatal(&format!("fork failed: {err}")))
+    };
+    graph
+        .verify()
+        .unwrap_or_else(|err| fatal(&format!("Rootprint verification failed: {err}")));
+    write_json(&output, &graph);
+    println!("branch: {branch_id}");
+    println!("rootprint: {}", output.display());
+}
+
+fn cmd_rootprint_verify(args: Vec<String>) {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_rootprint_help();
+        return;
+    }
+    if args.len() != 1 {
+        fatal("verify requires <rootprint.json>");
+    }
+    let graph = read_rootprint(Path::new(&args[0]));
+    graph
+        .verify()
+        .unwrap_or_else(|err| fatal(&format!("Rootprint verification failed: {err}")));
+    println!(
+        "PASS: Rootprint core verified ({} branches, root {}).",
+        graph.branches.len(),
+        graph.root_branch
+    );
+}
+
+fn cmd_rootprint_equivalent(args: Vec<String>) {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_rootprint_help();
+        return;
+    }
+    if args.len() != 3 {
+        fatal("equivalent requires <rootprint.json> <left> <right>");
+    }
+    let graph = read_rootprint(Path::new(&args[0]));
+    graph
+        .verify()
+        .unwrap_or_else(|err| fatal(&format!("Rootprint verification failed: {err}")));
+    let equivalent = graph
+        .equivalent(&args[1], &args[2])
+        .unwrap_or_else(|err| fatal(&err.to_string()));
+    println!(
+        "{}",
+        if equivalent {
+            "equivalent"
+        } else {
+            "different"
+        }
+    );
+}
+
+fn cmd_attach_external_proof(args: Vec<String>) {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_attach_external_proof_help();
+        return;
+    }
+    let mut artifact_path = None;
+    let mut id = None;
+    let mut proof_system = None;
+    let mut payload = None;
+    let mut verifier_hint = None;
+    let mut metadata = None;
+    let mut output = None;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--id" => id = Some(take_option(&mut iter, "--id")),
+            "--proof-system" => proof_system = Some(take_option(&mut iter, "--proof-system")),
+            "--payload" => payload = Some(PathBuf::from(take_option(&mut iter, "--payload"))),
+            "--verifier-hint" => verifier_hint = Some(take_option(&mut iter, "--verifier-hint")),
+            "--metadata" => metadata = Some(PathBuf::from(take_option(&mut iter, "--metadata"))),
+            "--output" => output = Some(PathBuf::from(take_option(&mut iter, "--output"))),
+            value if artifact_path.is_none() => artifact_path = Some(PathBuf::from(value)),
+            other => fatal(&format!("unknown argument: {other}")),
+        }
+    }
+    let artifact_path = artifact_path.unwrap_or_else(|| fatal("artifact.pha is required"));
+    let output = output.unwrap_or_else(|| artifact_path.clone());
+    let payload_path = payload.unwrap_or_else(|| fatal("--payload is required"));
+    let mut artifact = read_pha(&artifact_path);
+    artifact
+        .verify()
+        .unwrap_or_else(|err| fatal(&format!("PHA core verification failed: {err}")));
+    let original_fingerprint = artifact.phx_fingerprint.clone();
+    let mut attachment = ExternalProofAttachment::new(
+        id.unwrap_or_else(|| fatal("--id is required")),
+        proof_system.unwrap_or_else(|| fatal("--proof-system is required")),
+        read_json_value(&payload_path),
+    )
+    .unwrap_or_else(|err| fatal(&format!("failed to create attachment: {err}")));
+    attachment.verifier_hint = verifier_hint;
+    attachment.metadata = metadata.map(|path| read_json_value(&path));
+    let attachments = artifact
+        .embedded_proof
+        .external_proof_attachments
+        .get_or_insert_with(Vec::new);
+    if attachments
+        .iter()
+        .any(|existing| existing.id == attachment.id)
+    {
+        fatal(&format!("attachment id already exists: {}", attachment.id));
+    }
+    attachments.push(attachment);
+    artifact
+        .verify_external_proof_attachments()
+        .unwrap_or_else(|err| fatal(&format!("attachment verification failed: {err}")));
+    if artifact.phx_fingerprint != original_fingerprint {
+        fatal("internal error: external attachment changed the Power House fingerprint");
+    }
+    write_json(&output, &artifact);
+    println!("phx_fingerprint: {}", artifact.phx_fingerprint);
+    println!("core_unchanged: true");
+    println!("artifact: {}", output.display());
 }
 
 #[cfg(feature = "net")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ mod log_parser;
 mod merkle;
 mod multilinear;
 mod prng;
+pub mod provenance;
 pub mod rollup;
 pub mod sparse_sumcheck;
 mod streaming;

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -1,0 +1,49 @@
+//! Portable provenance artifacts and deterministic identity.
+
+pub mod pha;
+pub mod rootprint;
+
+pub use pha::{EmbeddedProof, ExternalProofAttachment, PhaArtifact, PhaError, PHA_SCHEMA_V1};
+pub use rootprint::{Rootprint, RootprintBranch, RootprintError, ROOTPRINT_SCHEMA_V1};
+
+/// Creates or extends a Rootprint graph with a verified Power House artifact.
+///
+/// This is the recommended library interface for provenance-aware proof
+/// creation. Every form returns `Result<_, RootprintError>`.
+///
+/// ```
+/// use power_house::{prove_with_rootprint, provenance::PhaArtifact};
+/// use serde_json::json;
+///
+/// let artifact = PhaArtifact::new(
+///     json!({"source": "example"}),
+///     "power-house/example/v1",
+///     json!({"claim": 7}),
+///     json!({"valid": true}),
+/// )?;
+/// let graph = prove_with_rootprint!(label: "main", artifact: artifact)?;
+/// graph.verify()?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[macro_export]
+macro_rules! prove_with_rootprint {
+    (label: $label:expr, artifact: $artifact:expr $(,)?) => {
+        $crate::provenance::Rootprint::new($label, $artifact)
+    };
+    (
+        rootprint: $rootprint:expr,
+        fork: $parent:expr,
+        label: $label:expr,
+        artifact: $artifact:expr $(,)?
+    ) => {
+        $rootprint.fork($parent, $label, $artifact)
+    };
+    (
+        rootprint: $rootprint:expr,
+        merge: [$left:expr, $right:expr],
+        label: $label:expr,
+        artifact: $artifact:expr $(,)?
+    ) => {
+        $rootprint.merge($left, $right, $label, $artifact)
+    };
+}

--- a/src/provenance/pha.rs
+++ b/src/provenance/pha.rs
@@ -1,0 +1,463 @@
+//! Power House Archive (`.pha`) v1 artifacts.
+//!
+//! A `.pha` artifact binds a Power House proof and its provenance to a
+//! deterministic `phx_fingerprint`. Optional external proof attachments are
+//! deliberately outside that core identity. They can be transported alongside
+//! the artifact without changing whether the Power House artifact is valid.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::error::Error;
+use std::fmt;
+
+/// Schema identifier for Power House Archive v1 artifacts.
+pub const PHA_SCHEMA_V1: &str = "power-house/pha/v1";
+
+const PHX_FINGERPRINT_DOMAIN: &[u8] = b"power-house:pha:v1:phx-fingerprint\0";
+const SHA256_PREFIX: &str = "sha256:";
+
+/// A secondary proof transported with a `.pha` artifact.
+///
+/// Attachments are not part of the Power House core fingerprint or core
+/// verification path. `payload_sha256` binds the attachment payload when the
+/// caller explicitly invokes attachment verification.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExternalProofAttachment {
+    /// Stable attachment identifier within the artifact.
+    pub id: String,
+    /// External proof system or format name.
+    pub proof_system: String,
+    /// Opaque external proof payload.
+    pub payload: Value,
+    /// SHA-256 digest of canonical JSON serialization of `payload`.
+    pub payload_sha256: String,
+    /// Optional verifier or resolver hint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verifier_hint: Option<String>,
+    /// Optional non-core attachment metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+impl ExternalProofAttachment {
+    /// Creates an attachment and calculates its payload digest.
+    pub fn new(
+        id: impl Into<String>,
+        proof_system: impl Into<String>,
+        payload: Value,
+    ) -> Result<Self, PhaError> {
+        let payload_sha256 = digest_json(&payload)?;
+        Ok(Self {
+            id: id.into(),
+            proof_system: proof_system.into(),
+            payload,
+            payload_sha256,
+            verifier_hint: None,
+            metadata: None,
+        })
+    }
+
+    /// Verifies the attachment's structural fields and payload digest.
+    ///
+    /// This checks transport integrity only. Cryptographic semantics for an
+    /// external proof system belong in an explicit caller-supplied verifier.
+    pub fn verify_integrity(&self) -> Result<(), PhaError> {
+        if self.id.trim().is_empty() {
+            return Err(PhaError::InvalidAttachment(
+                "attachment id must not be empty".to_string(),
+            ));
+        }
+        if self.proof_system.trim().is_empty() {
+            return Err(PhaError::InvalidAttachment(
+                "attachment proof_system must not be empty".to_string(),
+            ));
+        }
+        validate_sha256(&self.payload_sha256)?;
+        let expected = digest_json(&self.payload)?;
+        if expected != self.payload_sha256 {
+            return Err(PhaError::AttachmentDigestMismatch {
+                attachment_id: self.id.clone(),
+                expected,
+                found: self.payload_sha256.clone(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// The Power House proof embedded in a `.pha` artifact.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EmbeddedProof {
+    /// Power House proof protocol identifier.
+    pub protocol: String,
+    /// Public inputs or statement bound to the proof.
+    pub public_inputs: Value,
+    /// Opaque protocol-specific Power House proof payload.
+    pub proof: Value,
+    /// Optional secondary proofs that never affect Power House core validity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_proof_attachments: Option<Vec<ExternalProofAttachment>>,
+}
+
+/// A portable Power House Archive artifact.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhaArtifact {
+    /// `.pha` schema identifier.
+    pub schema: String,
+    /// Core provenance data committed by the Power House fingerprint.
+    pub provenance: Value,
+    /// Embedded Power House proof and optional external attachments.
+    pub embedded_proof: EmbeddedProof,
+    /// Domain-separated SHA-256 identity of core fields.
+    pub phx_fingerprint: String,
+}
+
+impl PhaArtifact {
+    /// Creates a `.pha` v1 artifact and calculates its core fingerprint.
+    pub fn new(
+        provenance: Value,
+        protocol: impl Into<String>,
+        public_inputs: Value,
+        proof: Value,
+    ) -> Result<Self, PhaError> {
+        let mut artifact = Self {
+            schema: PHA_SCHEMA_V1.to_string(),
+            provenance,
+            embedded_proof: EmbeddedProof {
+                protocol: protocol.into(),
+                public_inputs,
+                proof,
+                external_proof_attachments: None,
+            },
+            phx_fingerprint: String::new(),
+        };
+        artifact.phx_fingerprint = artifact.calculate_phx_fingerprint()?;
+        Ok(artifact)
+    }
+
+    /// Calculates the fingerprint over Power House core fields only.
+    ///
+    /// `external_proof_attachments` and the stored `phx_fingerprint` are
+    /// intentionally excluded.
+    pub fn calculate_phx_fingerprint(&self) -> Result<String, PhaError> {
+        for (name, value) in [
+            ("provenance", &self.provenance),
+            (
+                "embedded_proof.public_inputs",
+                &self.embedded_proof.public_inputs,
+            ),
+            ("embedded_proof.proof", &self.embedded_proof.proof),
+        ] {
+            if !uses_canonical_json_numbers(value) {
+                return Err(PhaError::InvalidCore(format!(
+                    "{name} contains a non-integer JSON number"
+                )));
+            }
+        }
+        let core = serde_json::json!({
+            "embedded_proof": {
+                "proof": &self.embedded_proof.proof,
+                "protocol": &self.embedded_proof.protocol,
+                "public_inputs": &self.embedded_proof.public_inputs,
+            },
+            "provenance": &self.provenance,
+            "schema": &self.schema,
+        });
+        let encoded = serde_json::to_vec(&core).map_err(PhaError::Serialization)?;
+        let mut hasher = Sha256::new();
+        hasher.update(PHX_FINGERPRINT_DOMAIN);
+        hasher.update(encoded);
+        Ok(format!("{SHA256_PREFIX}{}", hex::encode(hasher.finalize())))
+    }
+
+    /// Recalculates and stores the Power House core fingerprint.
+    pub fn refresh_phx_fingerprint(&mut self) -> Result<(), PhaError> {
+        self.phx_fingerprint = self.calculate_phx_fingerprint()?;
+        Ok(())
+    }
+
+    /// Verifies `.pha` schema and core fingerprint validity.
+    ///
+    /// This method never reads or validates `external_proof_attachments`.
+    pub fn verify(&self) -> Result<(), PhaError> {
+        if self.schema != PHA_SCHEMA_V1 {
+            return Err(PhaError::UnsupportedSchema(self.schema.clone()));
+        }
+        if self.embedded_proof.protocol.trim().is_empty() {
+            return Err(PhaError::InvalidCore(
+                "embedded proof protocol must not be empty".to_string(),
+            ));
+        }
+        validate_sha256(&self.phx_fingerprint)?;
+        let expected = self.calculate_phx_fingerprint()?;
+        if expected != self.phx_fingerprint {
+            return Err(PhaError::CoreFingerprintMismatch {
+                expected,
+                found: self.phx_fingerprint.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Explicitly verifies attachment integrity after core verification.
+    ///
+    /// Absence of attachments is valid. This method does not interpret the
+    /// cryptographic semantics of external proof systems.
+    pub fn verify_external_proof_attachments(&self) -> Result<(), PhaError> {
+        self.verify()?;
+        if let Some(attachments) = &self.embedded_proof.external_proof_attachments {
+            for attachment in attachments {
+                attachment.verify_integrity()?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Explicitly verifies attachment integrity and caller-defined semantics.
+    pub fn verify_external_proof_attachments_with<F>(&self, mut verifier: F) -> Result<(), PhaError>
+    where
+        F: FnMut(&ExternalProofAttachment) -> Result<(), String>,
+    {
+        self.verify_external_proof_attachments()?;
+        if let Some(attachments) = &self.embedded_proof.external_proof_attachments {
+            for attachment in attachments {
+                verifier(attachment).map_err(|message| PhaError::ExternalVerifierRejected {
+                    attachment_id: attachment.id.clone(),
+                    message,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Errors returned by `.pha` construction and verification.
+#[derive(Debug)]
+pub enum PhaError {
+    /// JSON serialization failed.
+    Serialization(serde_json::Error),
+    /// The artifact schema is unsupported.
+    UnsupportedSchema(String),
+    /// A required core field is invalid.
+    InvalidCore(String),
+    /// A SHA-256 value is malformed.
+    InvalidDigest(String),
+    /// The stored core fingerprint does not match core content.
+    CoreFingerprintMismatch {
+        /// Recalculated core fingerprint.
+        expected: String,
+        /// Fingerprint stored in the artifact.
+        found: String,
+    },
+    /// An attachment field is structurally invalid.
+    InvalidAttachment(String),
+    /// Attachment payload integrity verification failed.
+    AttachmentDigestMismatch {
+        /// Attachment identifier.
+        attachment_id: String,
+        /// Recalculated attachment digest.
+        expected: String,
+        /// Digest stored in the attachment.
+        found: String,
+    },
+    /// A caller-supplied external proof verifier rejected an attachment.
+    ExternalVerifierRejected {
+        /// Attachment identifier.
+        attachment_id: String,
+        /// Verifier-provided reason.
+        message: String,
+    },
+}
+
+impl fmt::Display for PhaError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Serialization(error) => write!(formatter, "PHA serialization failed: {error}"),
+            Self::UnsupportedSchema(schema) => {
+                write!(formatter, "unsupported PHA schema: {schema}")
+            }
+            Self::InvalidCore(message) => write!(formatter, "invalid PHA core: {message}"),
+            Self::InvalidDigest(digest) => write!(formatter, "invalid SHA-256 digest: {digest}"),
+            Self::CoreFingerprintMismatch { expected, found } => write!(
+                formatter,
+                "PHA core fingerprint mismatch: expected {expected}, found {found}"
+            ),
+            Self::InvalidAttachment(message) => {
+                write!(formatter, "invalid external proof attachment: {message}")
+            }
+            Self::AttachmentDigestMismatch {
+                attachment_id,
+                expected,
+                found,
+            } => write!(
+                formatter,
+                "external proof attachment {attachment_id} digest mismatch: expected {expected}, found {found}"
+            ),
+            Self::ExternalVerifierRejected {
+                attachment_id,
+                message,
+            } => write!(
+                formatter,
+                "external verifier rejected attachment {attachment_id}: {message}"
+            ),
+        }
+    }
+}
+
+impl Error for PhaError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Serialization(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+fn digest_json(value: &Value) -> Result<String, PhaError> {
+    if !uses_canonical_json_numbers(value) {
+        return Err(PhaError::InvalidAttachment(
+            "attachment payload contains a non-integer JSON number".to_string(),
+        ));
+    }
+    let encoded = serde_json::to_vec(value).map_err(PhaError::Serialization)?;
+    Ok(format!(
+        "{SHA256_PREFIX}{}",
+        hex::encode(Sha256::digest(encoded))
+    ))
+}
+
+fn uses_canonical_json_numbers(value: &Value) -> bool {
+    match value {
+        Value::Number(number) => number.is_i64() || number.is_u64(),
+        Value::Array(values) => values.iter().all(uses_canonical_json_numbers),
+        Value::Object(values) => values.values().all(uses_canonical_json_numbers),
+        _ => true,
+    }
+}
+
+fn validate_sha256(digest: &str) -> Result<(), PhaError> {
+    let Some(hex_digest) = digest.strip_prefix(SHA256_PREFIX) else {
+        return Err(PhaError::InvalidDigest(digest.to_string()));
+    };
+    if hex_digest.len() != 64
+        || !hex_digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(PhaError::InvalidDigest(digest.to_string()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn artifact() -> PhaArtifact {
+        PhaArtifact::new(
+            json!({
+                "producer": "power-house",
+                "source_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }),
+            "power-house/sumcheck/v1",
+            json!({"claim": "42", "field": 101}),
+            json!({"rounds": [[12, 30], [7, 5]]}),
+        )
+        .unwrap()
+    }
+
+    fn attachment() -> ExternalProofAttachment {
+        ExternalProofAttachment::new(
+            "external-proof-1",
+            "example/external-proof/v1",
+            json!({"proof": "opaque", "public_inputs": [1, 2, 3]}),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn absent_attachments_are_not_serialized() {
+        let encoded = serde_json::to_value(artifact()).unwrap();
+        assert!(encoded["embedded_proof"]
+            .get("external_proof_attachments")
+            .is_none());
+    }
+
+    #[test]
+    fn core_fingerprint_is_identical_with_or_without_attachments() {
+        let base = artifact();
+        let mut attached = base.clone();
+        attached.embedded_proof.external_proof_attachments = Some(vec![attachment()]);
+
+        assert_eq!(
+            base.calculate_phx_fingerprint().unwrap(),
+            attached.calculate_phx_fingerprint().unwrap()
+        );
+        assert_eq!(base.phx_fingerprint, attached.phx_fingerprint);
+        assert!(base.verify().is_ok());
+        assert!(attached.verify().is_ok());
+    }
+
+    #[test]
+    fn attachment_mutation_does_not_change_core_validity() {
+        let mut attached = artifact();
+        attached.embedded_proof.external_proof_attachments = Some(vec![attachment()]);
+        let fingerprint = attached.phx_fingerprint.clone();
+
+        attached
+            .embedded_proof
+            .external_proof_attachments
+            .as_mut()
+            .unwrap()[0]
+            .payload = json!({"proof": "mutated"});
+
+        assert_eq!(attached.calculate_phx_fingerprint().unwrap(), fingerprint);
+        assert!(attached.verify().is_ok());
+        assert!(matches!(
+            attached.verify_external_proof_attachments(),
+            Err(PhaError::AttachmentDigestMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn core_mutation_invalidates_core_verification() {
+        let mut artifact = artifact();
+        artifact.embedded_proof.proof = json!({"rounds": []});
+        assert!(matches!(
+            artifact.verify(),
+            Err(PhaError::CoreFingerprintMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn explicit_external_verifier_is_separate_from_core_verification() {
+        let mut artifact = artifact();
+        artifact.embedded_proof.external_proof_attachments = Some(vec![attachment()]);
+
+        assert!(artifact.verify().is_ok());
+        let error = artifact
+            .verify_external_proof_attachments_with(|_| {
+                Err("external policy rejected proof".to_string())
+            })
+            .unwrap_err();
+        assert!(matches!(error, PhaError::ExternalVerifierRejected { .. }));
+    }
+
+    #[test]
+    fn non_integer_numbers_are_rejected_from_canonical_content() {
+        let error = PhaArtifact::new(
+            json!({"measurement": 1.5}),
+            "power-house/test/v1",
+            json!({}),
+            json!({}),
+        )
+        .unwrap_err();
+        assert!(matches!(error, PhaError::InvalidCore(_)));
+
+        let error = ExternalProofAttachment::new("epa", "external/test/v1", json!({"value": 1.5}))
+            .unwrap_err();
+        assert!(matches!(error, PhaError::InvalidAttachment(_)));
+    }
+}

--- a/src/provenance/rootprint.rs
+++ b/src/provenance/rootprint.rs
@@ -1,0 +1,426 @@
+//! Deterministic Power House provenance branching.
+//!
+//! Rootprint is a directed acyclic graph of `.pha` artifacts. Branch identity,
+//! navigation, forking, merging, equivalence, and graph verification use only
+//! Power House core fingerprints. External proof attachments remain optional
+//! transport data and never participate in these operations.
+
+use super::{PhaArtifact, PhaError};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+/// Schema identifier for Rootprint v1 documents.
+pub const ROOTPRINT_SCHEMA_V1: &str = "power-house/rootprint/v1";
+
+const BRANCH_ID_DOMAIN: &[u8] = b"power-house:rootprint:v1:branch-id\0";
+const SHA256_PREFIX: &str = "sha256:";
+
+/// A branch in a Rootprint provenance graph.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RootprintBranch {
+    /// Deterministic branch identifier.
+    pub id: String,
+    /// Human-readable branch label.
+    pub label: String,
+    /// Monotonic graph sequence used to prove parent-before-child ordering.
+    pub sequence: u64,
+    /// Zero parents for the root, one for forks, and two for merges.
+    pub parents: Vec<String>,
+    /// Power House artifact carried by this branch.
+    pub artifact: PhaArtifact,
+}
+
+impl RootprintBranch {
+    /// Calculates this branch's deterministic core identifier.
+    pub fn calculate_id(&self) -> Result<String, RootprintError> {
+        calculate_branch_id(&self.label, &self.parents, &self.artifact)
+    }
+}
+
+/// A deterministic Power House provenance graph.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Rootprint {
+    /// Rootprint schema identifier.
+    pub schema: String,
+    /// Identifier of the graph root branch.
+    pub root_branch: String,
+    /// Branches keyed by deterministic identifier.
+    pub branches: BTreeMap<String, RootprintBranch>,
+}
+
+impl Rootprint {
+    /// Creates a Rootprint graph from one verified Power House artifact.
+    pub fn new(label: impl Into<String>, artifact: PhaArtifact) -> Result<Self, RootprintError> {
+        artifact.verify().map_err(RootprintError::Pha)?;
+        let label = normalized_label(label.into())?;
+        let id = calculate_branch_id(&label, &[], &artifact)?;
+        let branch = RootprintBranch {
+            id: id.clone(),
+            label,
+            sequence: 0,
+            parents: Vec::new(),
+            artifact,
+        };
+        let mut branches = BTreeMap::new();
+        branches.insert(id.clone(), branch);
+        Ok(Self {
+            schema: ROOTPRINT_SCHEMA_V1.to_string(),
+            root_branch: id,
+            branches,
+        })
+    }
+
+    /// Resolves an exact ID, unique ID prefix, or unique branch label.
+    pub fn navigate(&self, selector: &str) -> Result<&RootprintBranch, RootprintError> {
+        if let Some(branch) = self.branches.get(selector) {
+            return Ok(branch);
+        }
+        let mut matches = self
+            .branches
+            .values()
+            .filter(|branch| branch.id.starts_with(selector) || branch.label == selector);
+        let Some(first) = matches.next() else {
+            return Err(RootprintError::BranchNotFound(selector.to_string()));
+        };
+        if matches.next().is_some() {
+            return Err(RootprintError::AmbiguousSelector(selector.to_string()));
+        }
+        Ok(first)
+    }
+
+    /// Creates a one-parent branch and returns its deterministic ID.
+    pub fn fork(
+        &mut self,
+        parent: &str,
+        label: impl Into<String>,
+        artifact: PhaArtifact,
+    ) -> Result<String, RootprintError> {
+        artifact.verify().map_err(RootprintError::Pha)?;
+        let parent = self.navigate(parent)?.clone();
+        let label = normalized_label(label.into())?;
+        let parents = vec![parent.id];
+        let id = calculate_branch_id(&label, &parents, &artifact)?;
+        self.insert_branch(RootprintBranch {
+            id: id.clone(),
+            label,
+            sequence: parent.sequence.saturating_add(1),
+            parents,
+            artifact,
+        })?;
+        Ok(id)
+    }
+
+    /// Creates a two-parent merge branch and returns its deterministic ID.
+    pub fn merge(
+        &mut self,
+        left: &str,
+        right: &str,
+        label: impl Into<String>,
+        artifact: PhaArtifact,
+    ) -> Result<String, RootprintError> {
+        artifact.verify().map_err(RootprintError::Pha)?;
+        let left = self.navigate(left)?.clone();
+        let right = self.navigate(right)?.clone();
+        if left.id == right.id {
+            return Err(RootprintError::DuplicateMergeParent(left.id));
+        }
+        let label = normalized_label(label.into())?;
+        let mut parents = vec![left.id, right.id];
+        parents.sort();
+        let id = calculate_branch_id(&label, &parents, &artifact)?;
+        self.insert_branch(RootprintBranch {
+            id: id.clone(),
+            label,
+            sequence: left.sequence.max(right.sequence).saturating_add(1),
+            parents,
+            artifact,
+        })?;
+        Ok(id)
+    }
+
+    /// Returns whether two branches carry the same Power House core identity.
+    ///
+    /// External proof attachments are ignored.
+    pub fn equivalent(&self, left: &str, right: &str) -> Result<bool, RootprintError> {
+        let left = self.navigate(left)?;
+        let right = self.navigate(right)?;
+        Ok(left.artifact.phx_fingerprint == right.artifact.phx_fingerprint)
+    }
+
+    /// Verifies the complete Rootprint graph using Power House core data only.
+    pub fn verify(&self) -> Result<(), RootprintError> {
+        if self.schema != ROOTPRINT_SCHEMA_V1 {
+            return Err(RootprintError::UnsupportedSchema(self.schema.clone()));
+        }
+        let root = self
+            .branches
+            .get(&self.root_branch)
+            .ok_or_else(|| RootprintError::BranchNotFound(self.root_branch.clone()))?;
+        if root.sequence != 0 || !root.parents.is_empty() {
+            return Err(RootprintError::InvalidGraph(
+                "root branch must have sequence 0 and no parents".to_string(),
+            ));
+        }
+
+        for (key, branch) in &self.branches {
+            if key != &branch.id {
+                return Err(RootprintError::InvalidGraph(format!(
+                    "branch map key {key} does not match branch id {}",
+                    branch.id
+                )));
+            }
+            branch.artifact.verify().map_err(RootprintError::Pha)?;
+            let expected = branch.calculate_id()?;
+            if expected != branch.id {
+                return Err(RootprintError::BranchIdMismatch {
+                    expected,
+                    found: branch.id.clone(),
+                });
+            }
+            if branch.parents.len() > 2 {
+                return Err(RootprintError::InvalidGraph(format!(
+                    "branch {} has more than two parents",
+                    branch.id
+                )));
+            }
+            if branch.id != self.root_branch && branch.parents.is_empty() {
+                return Err(RootprintError::InvalidGraph(format!(
+                    "non-root branch {} has no parent",
+                    branch.id
+                )));
+            }
+            if branch.parents.windows(2).any(|pair| pair[0] >= pair[1]) {
+                return Err(RootprintError::InvalidGraph(format!(
+                    "branch {} parents must be sorted and unique",
+                    branch.id
+                )));
+            }
+            for parent_id in &branch.parents {
+                let parent = self
+                    .branches
+                    .get(parent_id)
+                    .ok_or_else(|| RootprintError::BranchNotFound(parent_id.clone()))?;
+                if parent.sequence >= branch.sequence {
+                    return Err(RootprintError::InvalidGraph(format!(
+                        "branch {} does not follow parent {}",
+                        branch.id, parent_id
+                    )));
+                }
+            }
+        }
+
+        let mut children: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+        for branch in self.branches.values() {
+            for parent in &branch.parents {
+                children
+                    .entry(parent.as_str())
+                    .or_default()
+                    .push(branch.id.as_str());
+            }
+        }
+
+        let mut reachable = BTreeSet::new();
+        let mut stack = vec![self.root_branch.clone()];
+        while let Some(branch_id) = stack.pop() {
+            if !reachable.insert(branch_id.clone()) {
+                continue;
+            }
+            if let Some(branch_children) = children.get(branch_id.as_str()) {
+                stack.extend(branch_children.iter().map(|child| (*child).to_string()));
+            }
+        }
+        if reachable.len() != self.branches.len() {
+            return Err(RootprintError::InvalidGraph(
+                "graph contains a branch unreachable from the root".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Explicitly verifies attachment integrity on every branch.
+    ///
+    /// This operation is separate from Rootprint core verification.
+    pub fn verify_external_proof_attachments(&self) -> Result<(), RootprintError> {
+        self.verify()?;
+        for branch in self.branches.values() {
+            branch
+                .artifact
+                .verify_external_proof_attachments()
+                .map_err(RootprintError::Pha)?;
+        }
+        Ok(())
+    }
+
+    fn insert_branch(&mut self, branch: RootprintBranch) -> Result<(), RootprintError> {
+        if self.branches.contains_key(&branch.id) {
+            return Err(RootprintError::DuplicateBranch(branch.id));
+        }
+        self.branches.insert(branch.id.clone(), branch);
+        Ok(())
+    }
+}
+
+/// Errors returned by Rootprint operations.
+#[derive(Debug)]
+pub enum RootprintError {
+    /// A `.pha` artifact failed core or explicit attachment verification.
+    Pha(PhaError),
+    /// The Rootprint schema is unsupported.
+    UnsupportedSchema(String),
+    /// A branch selector matched nothing.
+    BranchNotFound(String),
+    /// A branch selector matched multiple branches.
+    AmbiguousSelector(String),
+    /// A branch with the same deterministic identity already exists.
+    DuplicateBranch(String),
+    /// A merge specified the same parent twice.
+    DuplicateMergeParent(String),
+    /// A branch label is invalid.
+    InvalidLabel(String),
+    /// The stored branch ID does not match core branch data.
+    BranchIdMismatch {
+        /// Recalculated deterministic ID.
+        expected: String,
+        /// Stored branch ID.
+        found: String,
+    },
+    /// The graph violates Rootprint invariants.
+    InvalidGraph(String),
+    /// Rootprint serialization failed.
+    Serialization(serde_json::Error),
+}
+
+impl fmt::Display for RootprintError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pha(error) => write!(formatter, "PHA verification failed: {error}"),
+            Self::UnsupportedSchema(schema) => {
+                write!(formatter, "unsupported Rootprint schema: {schema}")
+            }
+            Self::BranchNotFound(selector) => write!(formatter, "branch not found: {selector}"),
+            Self::AmbiguousSelector(selector) => {
+                write!(formatter, "ambiguous branch selector: {selector}")
+            }
+            Self::DuplicateBranch(id) => write!(formatter, "branch already exists: {id}"),
+            Self::DuplicateMergeParent(id) => {
+                write!(formatter, "merge parents resolve to the same branch: {id}")
+            }
+            Self::InvalidLabel(label) => write!(formatter, "invalid branch label: {label:?}"),
+            Self::BranchIdMismatch { expected, found } => write!(
+                formatter,
+                "Rootprint branch ID mismatch: expected {expected}, found {found}"
+            ),
+            Self::InvalidGraph(message) => write!(formatter, "invalid Rootprint graph: {message}"),
+            Self::Serialization(error) => {
+                write!(formatter, "Rootprint serialization failed: {error}")
+            }
+        }
+    }
+}
+
+impl Error for RootprintError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Pha(error) => Some(error),
+            Self::Serialization(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+fn normalized_label(label: String) -> Result<String, RootprintError> {
+    let trimmed = label.trim();
+    if trimmed.is_empty() || trimmed.len() > 128 || trimmed.chars().any(char::is_control) {
+        return Err(RootprintError::InvalidLabel(label));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn calculate_branch_id(
+    label: &str,
+    parents: &[String],
+    artifact: &PhaArtifact,
+) -> Result<String, RootprintError> {
+    artifact.verify().map_err(RootprintError::Pha)?;
+    let encoded = serde_json::to_vec(&serde_json::json!({
+        "artifact_phx_fingerprint": artifact.phx_fingerprint,
+        "label": label,
+        "parents": parents,
+    }))
+    .map_err(RootprintError::Serialization)?;
+    let mut hasher = Sha256::new();
+    hasher.update(BRANCH_ID_DOMAIN);
+    hasher.update(encoded);
+    Ok(format!("{SHA256_PREFIX}{}", hex::encode(hasher.finalize())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provenance::ExternalProofAttachment;
+    use serde_json::json;
+
+    fn artifact(value: u64) -> PhaArtifact {
+        PhaArtifact::new(
+            json!({"source": "rootprint-test"}),
+            "power-house/test/v1",
+            json!({"value": value}),
+            json!({"accepted": true}),
+        )
+        .unwrap()
+    }
+
+    fn attachment() -> ExternalProofAttachment {
+        ExternalProofAttachment::new("epa", "external/test/v1", json!({"proof": "x"})).unwrap()
+    }
+
+    #[test]
+    fn branching_and_merging_are_core_only() {
+        let root_artifact = artifact(1);
+        let mut graph = Rootprint::new("main", root_artifact.clone()).unwrap();
+
+        let mut with_epa = root_artifact.clone();
+        with_epa.embedded_proof.external_proof_attachments = Some(vec![attachment()]);
+        let left = graph.fork("main", "left", with_epa.clone()).unwrap();
+
+        with_epa
+            .embedded_proof
+            .external_proof_attachments
+            .as_mut()
+            .unwrap()[0]
+            .payload = json!({"proof": "mutated"});
+        let right = graph.fork("main", "right", with_epa).unwrap();
+        let merged = graph.merge(&left, &right, "merged", artifact(2)).unwrap();
+
+        assert!(graph.verify().is_ok());
+        assert!(graph.equivalent(&left, &right).unwrap());
+        assert_eq!(graph.navigate("merged").unwrap().id, merged);
+        assert!(graph.verify_external_proof_attachments().is_err());
+    }
+
+    #[test]
+    fn attachment_presence_does_not_change_branch_id() {
+        let base = artifact(1);
+        let graph_without = Rootprint::new("main", base.clone()).unwrap();
+        let mut attached = base;
+        attached.embedded_proof.external_proof_attachments = Some(vec![attachment()]);
+        let graph_with = Rootprint::new("main", attached).unwrap();
+        assert_eq!(graph_without.root_branch, graph_with.root_branch);
+    }
+
+    #[test]
+    fn core_mutation_breaks_graph_verification() {
+        let mut graph = Rootprint::new("main", artifact(1)).unwrap();
+        graph
+            .branches
+            .get_mut(&graph.root_branch)
+            .unwrap()
+            .artifact
+            .embedded_proof
+            .proof = json!({"accepted": false});
+        assert!(graph.verify().is_err());
+    }
+}

--- a/tests/provenance_protocol.rs
+++ b/tests/provenance_protocol.rs
@@ -1,0 +1,130 @@
+use power_house::{
+    prove_with_rootprint,
+    provenance::{ExternalProofAttachment, PhaArtifact, Rootprint},
+};
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+
+fn artifact(claim: u64) -> PhaArtifact {
+    PhaArtifact::new(
+        json!({"producer": "integration-test", "run": 7}),
+        "power-house/integration/v1",
+        json!({"claim": claim}),
+        json!({"verified": true}),
+    )
+    .unwrap()
+}
+
+fn with_attachment(mut artifact: PhaArtifact, payload: &str) -> PhaArtifact {
+    artifact.embedded_proof.external_proof_attachments = Some(vec![ExternalProofAttachment::new(
+        "external-1",
+        "example/external/v1",
+        json!({"proof": payload}),
+    )
+    .unwrap()]);
+    artifact
+}
+
+#[test]
+fn branching_is_identical_with_and_without_external_attachments() {
+    let plain = artifact(1);
+    let attached = with_attachment(plain.clone(), "original");
+
+    let plain_graph = prove_with_rootprint!(label: "main", artifact: plain).unwrap();
+    let attached_graph = prove_with_rootprint!(label: "main", artifact: attached).unwrap();
+
+    assert_eq!(plain_graph.root_branch, attached_graph.root_branch);
+    assert!(plain_graph.verify().is_ok());
+    assert!(attached_graph.verify().is_ok());
+}
+
+#[test]
+fn fork_merge_and_equivalence_never_require_external_attachments() {
+    let root = artifact(1);
+    let mut graph = Rootprint::new("main", root.clone()).unwrap();
+
+    let left = prove_with_rootprint!(
+        rootprint: &mut graph,
+        fork: "main",
+        label: "left",
+        artifact: with_attachment(root.clone(), "left"),
+    )
+    .unwrap();
+    let right = prove_with_rootprint!(
+        rootprint: &mut graph,
+        fork: "main",
+        label: "right",
+        artifact: root,
+    )
+    .unwrap();
+
+    assert!(graph.equivalent(&left, &right).unwrap());
+
+    let merged = prove_with_rootprint!(
+        rootprint: &mut graph,
+        merge: [&left, &right],
+        label: "accepted",
+        artifact: artifact(2),
+    )
+    .unwrap();
+    assert_eq!(graph.navigate("accepted").unwrap().id, merged);
+    assert!(graph.verify().is_ok());
+}
+
+#[test]
+fn epa_mutation_preserves_graph_validity_but_fails_explicit_integrity() {
+    let mut graph = Rootprint::new("main", with_attachment(artifact(1), "original")).unwrap();
+    let root = graph.branches.get_mut(&graph.root_branch).unwrap();
+    root.artifact
+        .embedded_proof
+        .external_proof_attachments
+        .as_mut()
+        .unwrap()[0]
+        .payload = json!({"proof": "mutated"});
+
+    assert!(graph.verify().is_ok());
+    assert!(graph.verify_external_proof_attachments().is_err());
+}
+
+#[test]
+fn conformance_vectors_reject_core_mutations_and_isolate_epa_mutations() {
+    let vector_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("conformance/pha-v1");
+    let core: PhaArtifact =
+        serde_json::from_slice(&fs::read(vector_dir.join("core-valid.pha")).unwrap()).unwrap();
+    let attached: PhaArtifact =
+        serde_json::from_slice(&fs::read(vector_dir.join("core-with-epa.pha")).unwrap()).unwrap();
+    let graph: Rootprint =
+        serde_json::from_slice(&fs::read(vector_dir.join("rootprint-valid.json")).unwrap())
+            .unwrap();
+
+    core.verify().unwrap();
+    attached.verify_external_proof_attachments().unwrap();
+    graph.verify().unwrap();
+    assert_eq!(core.phx_fingerprint, attached.phx_fingerprint);
+
+    type ArtifactMutation = Box<dyn Fn(&mut PhaArtifact)>;
+    let mutations: Vec<ArtifactMutation> = vec![
+        Box::new(|artifact| artifact.schema.push_str("-mutated")),
+        Box::new(|artifact| artifact.provenance = json!({"mutated": true})),
+        Box::new(|artifact| artifact.embedded_proof.protocol.push_str("-mutated")),
+        Box::new(|artifact| artifact.embedded_proof.public_inputs = json!({"claim": 0})),
+        Box::new(|artifact| artifact.embedded_proof.proof = json!({"accepted": false})),
+        Box::new(|artifact| artifact.phx_fingerprint.replace_range(7..8, "0")),
+    ];
+    for mutate in mutations {
+        let mut artifact = core.clone();
+        mutate(&mut artifact);
+        assert!(artifact.verify().is_err());
+    }
+
+    let mut epa_mutation = attached;
+    epa_mutation
+        .embedded_proof
+        .external_proof_attachments
+        .as_mut()
+        .unwrap()[0]
+        .payload = json!({"proof": "mutated"});
+    epa_mutation.verify().unwrap();
+    assert!(epa_mutation.verify_external_proof_attachments().is_err());
+}

--- a/tests/rootprint_cli.rs
+++ b/tests/rootprint_cli.rs
@@ -1,0 +1,130 @@
+use power_house::provenance::PhaArtifact;
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_dir() -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("power-house-rootprint-{suffix}"));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn write_json(path: &Path, value: &impl serde::Serialize) {
+    fs::write(path, serde_json::to_vec_pretty(value).unwrap()).unwrap();
+}
+
+fn run(args: &[&str]) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_julian"))
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "julian {:?} failed:\nstdout={}\nstderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn cli_runs_core_rootprint_workflow_and_separate_attachment_command() {
+    let dir = temp_dir();
+    let artifact_path = dir.join("main.pha");
+    let attached_path = dir.join("attached.pha");
+    let payload_path = dir.join("external.json");
+    let rootprint_path = dir.join("graph.json");
+
+    let artifact = PhaArtifact::new(
+        json!({"source": "cli-test"}),
+        "power-house/cli-test/v1",
+        json!({"claim": 9}),
+        json!({"proof": "ok"}),
+    )
+    .unwrap();
+    write_json(&artifact_path, &artifact);
+    write_json(&payload_path, &json!({"external": "opaque"}));
+
+    let attach_output = run(&[
+        "attach-external-proof",
+        artifact_path.to_str().unwrap(),
+        "--id",
+        "external-1",
+        "--proof-system",
+        "external/test/v1",
+        "--payload",
+        payload_path.to_str().unwrap(),
+        "--output",
+        attached_path.to_str().unwrap(),
+    ]);
+    assert!(attach_output.contains("core_unchanged: true"));
+
+    run(&[
+        "rootprint",
+        "init",
+        artifact_path.to_str().unwrap(),
+        "--label",
+        "main",
+        "--output",
+        rootprint_path.to_str().unwrap(),
+    ]);
+    run(&[
+        "rootprint",
+        "fork",
+        rootprint_path.to_str().unwrap(),
+        "main",
+        attached_path.to_str().unwrap(),
+        "--label",
+        "with-epa",
+    ]);
+    run(&[
+        "rootprint",
+        "fork",
+        rootprint_path.to_str().unwrap(),
+        "main",
+        artifact_path.to_str().unwrap(),
+        "--label",
+        "pure",
+    ]);
+    assert_eq!(
+        run(&[
+            "rootprint",
+            "equivalent",
+            rootprint_path.to_str().unwrap(),
+            "with-epa",
+            "pure",
+        ])
+        .trim(),
+        "equivalent"
+    );
+    run(&[
+        "rootprint",
+        "merge",
+        rootprint_path.to_str().unwrap(),
+        "with-epa",
+        "pure",
+        artifact_path.to_str().unwrap(),
+        "--label",
+        "accepted",
+    ]);
+    assert!(
+        run(&["rootprint", "verify", rootprint_path.to_str().unwrap(),])
+            .contains("PASS: Rootprint core verified")
+    );
+    assert!(run(&[
+        "rootprint",
+        "navigate",
+        rootprint_path.to_str().unwrap(),
+        "accepted",
+    ])
+    .contains("\"label\": \"accepted\""));
+
+    fs::remove_dir_all(dir).unwrap();
+}


### PR DESCRIPTION
## What changed

- adds Power House Archive (`.pha`) v1 with deterministic core fingerprints
- adds Rootprint v1 branching, merging, navigation, equivalence, macro, and CLI workflow
- keeps external proof attachments strictly optional and outside core identity
- adds a zero-dependency Python SDK and cross-language conformance vectors
- publishes measured v0.3.0 benchmarks and complete release documentation
- upgrades mfenx.com with browser-native Rootprint and PHA verification

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --locked`
- `cargo test --all-targets --features net --locked`
- CLI and RPC contract test scripts
- Rust/Python conformance regeneration and mutation tests
- `cargo package --locked --allow-dirty`
- Chromium desktop and mobile viewport checks
- browser artifact hash and Rootprint core replay