### PR TITLE
Publish complete Power House v0.3.1 documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --all-features --no-deps
+
       - name: Test default targets
         run: cargo test --all-targets --locked
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "power_house"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "power_house"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["MFENX LLC"]
-description = "Deterministic sum-check proofs, commitment-bound sparse verification, and quorum ledger tooling."
+description = "Deterministic proofs, portable .pha provenance, Rootprint graphs, and optional quorum networking."
 documentation = "https://docs.rs/power_house"
 repository = "https://github.com/JROChub/power_house"
 homepage = "https://mfenx.com"
 readme = "README.md"
 license = "MIT OR BSD-2-Clause"
-keywords = ["cryptography", "proofs", "sum-check", "ledger", "verification"]
+keywords = ["cryptography", "proofs", "provenance", "sum-check", "verification"]
 categories = ["cryptography", "algorithms", "mathematics"]
 include = [
   "Cargo.toml",
@@ -50,6 +50,10 @@ include = [
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 default = []

--- a/JULIAN_PROTOCOL.md
+++ b/JULIAN_PROTOCOL.md
@@ -1,5 +1,5 @@
 MFENX Power-House Network: The JULIAN Protocol Network
-Version 0.3.0 - June 2026
+Version 0.3.1 - June 2026
 
 
 # JULIAN Protocol: Proof-Transparent Consensus via Folding-Derived Anchors
@@ -11,9 +11,9 @@ proof-transparent ledger that derives consensus from folding-style interactive p
 Streaming sum-check provers produce deterministic Fiat–Shamir transcripts that are hashed into
 domain-separated BLAKE2b-256 anchors. These anchors are captured inside a ledger structure and
 reconciled across peers with a quorum predicate: once at least *q* replicas expose identical anchor
-sequences, the ledger state is final. The implementation retains a minimal dependency surface while
-leaning on BLAKE2b for transcript authenticity, and ships with reproducible logging and verification
-tooling.
+sequences, the ledger state is final. The implementation uses an explicit Rust
+dependency set, leans on BLAKE2b for transcript authenticity, and ships with
+reproducible logging and verification tooling.
 
 ## 1. Introduction
 
@@ -35,6 +35,8 @@ The JULIAN Protocol is implemented in the `power_house` crate. The key architect
 |-----------|----------------|-----------|
 | `StreamingPolynomial` | On-demand evaluation of multilinear polynomials without allocating the entire hypercube | `src/streaming.rs` |
 | `GeneralSumProof` | Non-interactive sum-check prover/verifier with deterministic Fiat–Shamir transcripts | `src/sumcheck.rs` |
+| `PhaArtifact` | Portable proof and provenance identity with optional non-core attachments | `src/provenance/pha.rs` |
+| `Rootprint` | Deterministic provenance graph for navigation, forks, merges, and equivalence | `src/provenance/rootprint.rs` |
 | `ProofLedger` | Ledger that stores statements, proofs, transcript hashes, Merkle roots, and audit logs | `src/julian.rs` |
 | Ledger Anchors | `EntryAnchor` (statements, transcripts, Merkle root) aggregated into `LedgerAnchor` | `src/julian.rs` |
 | Quorum Reconciliation | `reconcile_anchors` and `reconcile_anchors_with_quorum` determine validity/finality | `src/julian.rs` |
@@ -115,8 +117,9 @@ for Byzantine tolerance.
 4. **Forensics** – Errant anchors are investigated by retrieving the corresponding ASCII log and
    re-running `verify_logs`; this isolates the exact transcript responsible for divergence.
 
-Because all primitives (hashing, polynomial evaluation, transcript generation) use only the standard
-library, the protocol remains lightweight and deterministic across platforms.
+The protocol uses deterministic crate APIs for hashing, polynomial evaluation,
+and transcript generation so independently configured nodes can reproduce the
+same anchor state.
 
 ## 6. Implementation Details
 
@@ -138,6 +141,8 @@ library, the protocol remains lightweight and deterministic across platforms.
   <code>N</code> broadcasts (`--checkpoint-interval N`), enabling fast bootstrap by replaying only
   logs newer than the last checkpoint.
 - **Examples**:
+  - `rootprint_workflow`: creates and verifies a forked and merged provenance graph.
+  - `pha_conformance_vectors`: regenerates Rust/Python `.pha` and Rootprint vectors.
   - `hash_pipeline`: illustrates the end-to-end protocol on two nodes, including log directories.
   - `scale_sumcheck`: streaming benchmark with optional CSV output (`POWER_HOUSE_SCALE_OUT`).
   - `sextillion_verify`: closed-form constant-polynomial certificate over `2^70` Boolean points.

--- a/README.md
+++ b/README.md
@@ -1,193 +1,205 @@
-# power_house
+# Power House
 
 [![CI](https://img.shields.io/github/actions/workflow/status/JROChub/power_house/ci.yml?branch=main&label=CI)](https://github.com/JROChub/power_house/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/power_house)](https://crates.io/crates/power_house)
 [![docs.rs](https://img.shields.io/docsrs/power_house)](https://docs.rs/power_house)
 [![license](https://img.shields.io/crates/l/power_house)](LICENSE)
 
-`power_house` is a Rust verification stack for deterministic sum-check proofs,
-portable proof provenance, commitment-bound sparse workloads, transcript
-anchoring, and optional quorum networking.
+Power House is a deterministic verification and provenance stack for Rust. It
+combines structured sum-check proofs, portable `.pha` artifacts, Rootprint
+proof-history graphs, commitment-bound sparse workloads, transcript anchoring,
+and an optional quorum network.
 
-Power House Archive (`.pha`) and Rootprint are the primary provenance workflow.
-A `.pha` file binds core proof data and provenance to a deterministic
-`phx_fingerprint`. Rootprint adds verifiable navigation, forks, merges, and
-equivalence over those core identities.
+The primary workflow is **Power House + Rootprint**:
 
-External proof attachments are optional transport data. They never affect a
-Power House fingerprint, Rootprint branch ID, core verification, or branch
-equivalence.
+- **Power House Archive (`.pha`)** binds proof data and provenance to a
+  deterministic `phx_fingerprint`.
+- **Rootprint** provides verifiable navigation, forks, merges, and equivalence
+  over `.pha` core identities.
+- **External proof attachments (EPA)** are optional transport data and remain
+  outside the Power House core fingerprint and Rootprint branch identity.
 
-## Power House + Rootprint
+## Quick Start
+
+```bash
+cargo add power_house
+```
 
 ```rust
 use power_house::{prove_with_rootprint, provenance::PhaArtifact};
 use serde_json::json;
 
-let artifact = PhaArtifact::new(
-    json!({"producer": "example"}),
-    "power-house/example/v1",
-    json!({"claim": 7}),
-    json!({"accepted": true}),
-)?;
-let graph = prove_with_rootprint!(label: "main", artifact: artifact)?;
-graph.verify()?;
-# Ok::<(), Box<dyn std::error::Error>>(())
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let artifact = PhaArtifact::new(
+        json!({"producer": "example"}),
+        "power-house/example/v1",
+        json!({"claim": 7}),
+        json!({"accepted": true}),
+    )?;
+
+    let graph = prove_with_rootprint!(
+        label: "main",
+        artifact: artifact,
+    )?;
+    graph.verify()?;
+    Ok(())
+}
 ```
 
-The `julian rootprint` workflow navigates, forks, merges, compares, and verifies
-portable graphs. `julian attach-external-proof` is deliberately separate from
-the core engine.
-
-## Verified Scale
-
-The repository contains four reproducible proof modes:
-
-| Mode | Public domain | Verifier work | Command |
-| --- | ---: | ---: | --- |
-| Constant polynomial | `2^70` points | `O(70)` | `cargo run --release --example sextillion_verify` |
-| Seeded affine polynomial | `2^4096` points | `O(4096)` | `cargo run --release --example hyperscale_affine` |
-| Seeded sparse polynomial | `2^1,000,000` points | `O(n + I log n)` | `cargo run --release --example sparse_record` |
-| External committed sparse polynomial | `2^1,000,000` points | `O(n + I log n)` | `cargo run --release --example committed_workload` |
-
-Here `n` is the number of variables and `I` is the number of nonzero variable
-incidences. None of these modes allocates the expanded Boolean hypercube.
-
-The external workflow stores the polynomial and proof separately:
-
-- `PHSMv1`: canonical sparse polynomial
-- `PHCPv1`: proof containing a domain-separated BLAKE2b-256 commitment
-
-Verification requires both files and rejects workload substitution.
-
-## Install
+Install the `julian` CLI with the network feature:
 
 ```bash
-cargo add power_house
 cargo install power_house --features net
 ```
+
+The primary provenance commands are:
+
+```bash
+julian rootprint init main.pha --label main --output proof.rootprint.json
+julian rootprint fork proof.rootprint.json main candidate.pha --label candidate
+julian rootprint navigate proof.rootprint.json candidate
+julian rootprint verify proof.rootprint.json
+```
+
+## Verification Profiles
+
+| Profile | Public statement | Verifier path | Reproduce |
+| --- | --- | --- | --- |
+| Constant sum-check | `2^70` Boolean points | 70 field rounds | `cargo run --release --example sextillion_verify` |
+| Seeded affine sum-check | `2^4096` Boolean points | 4,096 field rounds | `cargo run --release --example hyperscale_affine` |
+| Seeded sparse certificate | `2^1,000,000` Boolean points | `O(n + I log n)` deterministic replay | `cargo run --release --example sparse_record` |
+| Committed sparse workload | External `PHSMv1` + `PHCPv1` files | Commitment-bound deterministic replay | `cargo run --release --example committed_workload` |
+| Portable provenance | `.pha` core + Rootprint DAG | Fingerprint and graph replay | `cargo run --example rootprint_workflow` |
+
+Here `n` is the number of variables and `I` is the number of nonzero variable
+incidences. The proof modes operate on compact algebraic descriptions and do
+not allocate the expanded Boolean hypercube.
+
+## Core Formats
+
+| Format | Purpose |
+| --- | --- |
+| `.pha` v1 | Portable proof, public inputs, provenance, and core fingerprint |
+| Rootprint v1 | Deterministic proof-history graph with forks and merges |
+| `PHSPv1` | Seeded sparse polynomial certificate |
+| `PHSMv1` | Canonical external sparse polynomial |
+| `PHCPv1` | Certificate bound to a `PHSMv1` commitment |
+
+Rust and Python consume the same canonical vectors under `conformance/`.
+Mutation tests require core changes to reject while proving that EPA mutation
+does not alter Power House core validity.
 
 ## Reproduce
 
 ```bash
-cargo test --all-targets
-cargo test --all-targets --features net
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
+cargo test --all-targets --locked
+cargo test --all-targets --features net --locked
 
+cargo run --example pha_conformance_vectors
+cargo run --example rootprint_workflow
 cargo run --release --example sextillion_verify
 cargo run --release --example hyperscale_affine
 cargo run --release --example sparse_record
 cargo run --release --example committed_workload
-cargo run --example rootprint_workflow
-cargo run --example pha_conformance_vectors
 
-python3 scripts/verify_sparse_certificate.py \
-  target/power_house_sparse_record.phsp
-
-python3 scripts/verify_sparse_certificate.py \
-  target/external_interaction_model.phcp \
-  --polynomial target/external_interaction_model.phsm
-
+PYTHONPATH=sdk/python python3 -m unittest discover -s sdk/python/tests -v
 python3 scripts/test_sparse_verifier.py
 python3 scripts/soundness_budget.py
-PYTHONPATH=sdk/python python3 -m unittest discover -s sdk/python/tests -v
 ```
 
-The full procedure, formats, expected outputs, and failure tests are in
+The complete procedure and expected rejection behavior are documented in the
 [Verification Guide](docs/verification_guide.md).
 
-Small canonical files in `conformance/v1` are checked by both languages. Every
-single-byte XOR mutation of each vector must reject.
+## Primary Rust APIs
 
-## Library
+- [`PhaArtifact`](https://docs.rs/power_house/latest/power_house/provenance/struct.PhaArtifact.html):
+  portable Power House core identity.
+- [`Rootprint`](https://docs.rs/power_house/latest/power_house/provenance/struct.Rootprint.html):
+  deterministic proof-history branching and verification.
+- `prove_with_rootprint!`: recommended provenance-aware construction interface.
+- [`GeneralSumProof`](https://docs.rs/power_house/latest/power_house/struct.GeneralSumProof.html):
+  dense, streaming, constant, and seeded-affine sum-check.
+- [`SeededSparseProof`](https://docs.rs/power_house/latest/power_house/struct.SeededSparseProof.html):
+  stable `PHSPv1` certificates.
+- [`CommittedSparsePolynomial`](https://docs.rs/power_house/latest/power_house/struct.CommittedSparsePolynomial.html)
+  and
+  [`CommittedSparseProof`](https://docs.rs/power_house/latest/power_house/struct.CommittedSparseProof.html):
+  external workload binding.
+- [`ProofLedger`](https://docs.rs/power_house/latest/power_house/struct.ProofLedger.html):
+  transcript logs, anchors, and quorum reconciliation.
 
-```rust
-use power_house::{Field, GeneralSumProof};
+## Python SDK
 
-let field = Field::new(1_000_000_007);
-let proof = GeneralSumProof::prove_seeded_affine(
-    4096,
-    &field,
-    b"public reproducible workload",
-);
+The bundled zero-dependency Python SDK defaults to pure Power House + Rootprint:
 
-assert!(proof.verify_seeded_affine(
-    &field,
-    b"public reproducible workload",
-));
+```python
+from power_house import create_artifact, new_rootprint, verify_rootprint
+
+artifact = create_artifact(
+    {"source": "python"},
+    "power-house/example/v1",
+    {"claim": 7},
+    {"accepted": True},
+)
+graph = new_rootprint("main", artifact)
+verify_rootprint(graph)
 ```
 
-Primary APIs:
+EPA helpers require an explicit secondary import:
 
-- `GeneralSumProof`: dense, streaming, constant, and seeded-affine sum-check
-- `SeededSparseProof`: stable `PHSPv1` seeded sparse certificates
-- `CommittedSparsePolynomial`: canonical external sparse workloads
-- `CommittedSparseProof`: stable `PHCPv1` commitment-bound certificates
-- `PhaArtifact`: portable core proof and provenance identity
-- `Rootprint`: deterministic proof-history branching and equivalence
-- `prove_with_rootprint!`: recommended provenance-aware construction interface
-- `ProofLedger`: transcript logs, anchors, and quorum reconciliation
-
-## Network
-
-The `net` feature enables the `julian` CLI, libp2p transport, signed envelopes,
-data availability endpoints, governance policies, stake accounting, and token
-migration commands.
-
-```bash
-julian keygen ed25519://<seed> --out ./keys/node.identity
-
-julian net start \
-  --node-id <node_id> \
-  --log-dir ./logs/<node_id> \
-  --listen /ip4/0.0.0.0/tcp/0 \
-  --bootstrap /dns4/mfenx.com/tcp/7002/p2p/<PEER_ID> \
-  --quorum 2 \
-  --key ed25519://<seed>
+```python
+from power_house.external import attach_external_proof
 ```
 
-The native wallet lane accepts signed EIP-1559 transfers and exposes only
-quorum-finalized blocks, balances, nonces, transactions, and receipts:
+See [SDKs](docs/sdk.md) for installation and interoperability tests.
+
+## Network And RPC
+
+The optional `net` feature enables libp2p transport, signed envelopes, data
+availability services, governance policies, stake accounting, migration tools,
+and a quorum-finalized native JSON-RPC lane.
 
 ```bash
 julian net start \
-  --node-id <node_id> \
-  --log-dir ./logs/<node_id> \
-  --blob-dir ./data/<node_id> \
+  --node-id validator-1 \
+  --log-dir ./logs/validator-1 \
+  --blob-dir ./data/validator-1 \
   --listen /ip4/0.0.0.0/tcp/7001 \
-  --policy ./config/native-validators.json \
+  --policy ./configs/governance.stake.json \
   --quorum 2 \
   --evm-chain-id 177155 \
   --evm-rpc-listen 127.0.0.1:8545 \
   --key ed25519://<seed>
 ```
 
-Run `scripts/test_native_rpc_cluster.sh` to verify three independent replicas
-produce the same finalized block hash, state root, balances, and receipt.
-Use `scripts/generate_rpc_cluster.py` to create a sealed quorum-2 production
-bundle for three validators. The production runbook provisions the validators
-and global HTTPS edge on DigitalOcean.
-
-Operations and migration procedures are documented in
-[Operations](docs/ops.md) and [Mainnet Launch](docs/mainnet_launch.md).
+Use `scripts/test_native_rpc_cluster.sh` to verify replica finality and
+`scripts/check_rpc.py` to run the external publication gate.
 
 ## Documentation
 
-- [Verification Guide](docs/verification_guide.md)
+Start with the [Documentation Index](docs/README.md).
+
 - [Power House Archive v1](docs/pha_spec.md)
 - [Rootprint v1](docs/rootprint.md)
+- [Provenance Security Model](docs/provenance_security.md)
+- [Verification Guide](docs/verification_guide.md)
 - [SDKs](docs/sdk.md)
-- [v0.3.0 Benchmarks](benchmarks/v0.3.0/report.json)
 - [JULIAN Protocol](JULIAN_PROTOCOL.md)
-- [Committed Workload Format](docs/committed_workload.md)
-- [Million-Round Sparse Certificate](docs/sparse_record.md)
-- [Hyperscale Seeded-Affine Proof](docs/hyperscale_proof.md)
-- [Prior-Art Review](docs/prior_art_review.md)
-- [Sparse Certificate Security Model](docs/security_model.md)
-- [Research Protocol](docs/research_protocol.md)
-- [Orbital Observatory](docs/orbital_observatory.md)
-- [Operations](docs/ops.md)
+- [Sparse Security Model](docs/security_model.md)
 - [RPC Operations](docs/rpc_operations.md)
 - [Production RPC Deployment](docs/production_rpc_deployment.md)
+- [Orbital Observatory](docs/orbital_observatory.md)
+- [v0.3.0 Benchmark Report](benchmarks/v0.3.0/report.json)
+
+## Public Surfaces
+
+- API documentation: <https://docs.rs/power_house>
+- Package: <https://crates.io/crates/power_house>
+- Repository: <https://github.com/JROChub/power_house>
+- Public verifier: <https://mfenx.com>
 
 ## License
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## v0.3.1 - 2026-06-12
+
+### Documentation
+- Rebuilt the GitHub and crates.io README around Power House Archive,
+  Rootprint, proof profiles, SDKs, and current network operations.
+- Replaced the legacy rustdoc introduction with current `.pha`, Rootprint,
+  sum-check, sparse proof, and feature documentation.
+- Added an authoritative documentation index that separates current guides
+  from retained historical material.
+- Updated active protocol, SDK, verification, Observatory, RPC, and operations
+  guides to the v0.3.1 release surface.
+- Added docs.rs metadata to build all features and a CI gate that rejects
+  rustdoc warnings.
+- Fixed existing rustdoc markup and link warnings.
+
+### Metadata
+- Updated the crates.io description and keywords for portable provenance and
+  Rootprint.
+- Synchronized the bundled Python SDK and public verifier release labels.
+
 ## v0.3.0 - 2026-06-12
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,65 @@
+# Power House Documentation
+
+This index is the authoritative map for Power House v0.3.1 documentation.
+
+## Start Here
+
+| Document | Purpose |
+| --- | --- |
+| [Repository README](../README.md) | Installation, architecture, examples, and public links |
+| [Verification Guide](verification_guide.md) | Reproduce proof modes, conformance vectors, and rejection tests |
+| [Power House Archive v1](pha_spec.md) | Normative `.pha` core identity and optional EPA format |
+| [Rootprint v1](rootprint.md) | Normative branching, merging, navigation, and graph verification |
+| [Provenance Security Model](provenance_security.md) | Integrity boundary, assumptions, mutation behavior, and EPA isolation |
+| [SDKs](sdk.md) | Rust and Python interfaces and cross-language interoperability |
+| [JULIAN Protocol](../JULIAN_PROTOCOL.md) | Transcript anchoring, quorum reconciliation, and network architecture |
+
+## Proof Systems And Formats
+
+- [Sextillion-Scale Certificate](sextillion_proof.md)
+- [Hyperscale Seeded-Affine Proof](hyperscale_proof.md)
+- [Million-Round Sparse Certificate](sparse_record.md)
+- [Committed Sparse Workload](committed_workload.md)
+- [Sparse Certificate Security Model](security_model.md)
+- [Research Protocol](research_protocol.md)
+- [Prior-Art Review](prior_art_review.md)
+
+## Operations
+
+- [RPC Operations](rpc_operations.md)
+- [Production RPC Deployment](production_rpc_deployment.md)
+- [Network Operations](ops.md)
+- [Orbital Observatory](orbital_observatory.md)
+
+Operational commands must be tested against the release identified at the top
+of each active guide. Secrets, access tokens, private keys, and unredacted
+production configuration must never be committed.
+
+## Benchmarks And Conformance
+
+- [`conformance/pha-v1`](../conformance/pha-v1): `.pha` and Rootprint vectors
+- [`conformance/v1`](../conformance/v1): sparse proof vectors
+- [`benchmarks/v0.3.0/report.json`](../benchmarks/v0.3.0/report.json):
+  measured v0.3.0 report
+- [`benchmarks/README.md`](../benchmarks/README.md): benchmark reproduction
+
+Timing reports are environment-specific measurements. Protocol complexity and
+verification scope are defined in the corresponding specifications.
+
+## Historical Material
+
+The following documents are retained for traceability and are not the current
+release specification or deployment authority:
+
+- [Power-House Protocol Manual v0.1.57](book_of_power.md)
+- [Training Binder v0.1.54](training_binder.md)
+- [v0.1.54 Design Plan](roadmap_v0.1.54.md)
+- [Legacy Mainnet Launch Guide v0.1.54](mainnet_launch.md)
+- [Legacy Community Onboarding](community_onboarding.md)
+- [Legacy Permissionless Join Guide](permissionless_join.md)
+- [Legacy Tokenomics Notes](tokenomics.md)
+- [Legacy Uptime Bounty Policy](bounty_policy.md)
+- [Legacy Promotion Pack](promotion_pack.md)
+
+For current behavior, use the source code, conformance vectors, CI workflow,
+and active documents listed above.

--- a/docs/book_of_power.md
+++ b/docs/book_of_power.md
@@ -1,3 +1,9 @@
+Historical snapshot
+===================
+This manual is retained as the v0.1.57 protocol snapshot. It is not the
+current Power House release specification. Start with `docs/README.md`,
+`docs/pha_spec.md`, `docs/rootprint.md`, and `JULIAN_PROTOCOL.md` for v0.3.1.
+
 Power-House Protocol Manual
 ===========================
 Version: v0.1.57

--- a/docs/bounty_policy.md
+++ b/docs/bounty_policy.md
@@ -1,5 +1,8 @@
 # Uptime Bounty Policy (Phase 3)
 
+> Historical policy draft. No current bounty or payment commitment is created
+> by this document.
+
 ## Objective
 Reward operators that maintain stable, high‑availability nodes.
 

--- a/docs/committed_workload.md
+++ b/docs/committed_workload.md
@@ -1,5 +1,7 @@
 # Externally Committed Sparse Workload
 
+Status: active format guide for Power House v0.3.1.
+
 Power-House can now bind a sum-check certificate to a separately supplied
 sparse polynomial file.
 

--- a/docs/community_onboarding.md
+++ b/docs/community_onboarding.md
@@ -1,5 +1,9 @@
 # Community Node Onboarding (Phase 3)
 
+> Historical Phase 3 onboarding material. Bootstrap addresses, quorum values,
+> policies, and incentives must be obtained from the current operator release.
+> See [Documentation](README.md) and [Network Operations](ops.md).
+
 This guide covers a minimal operator path for joining the Power-House network and maintaining 90%+ uptime.
 
 ## Prerequisites
@@ -57,7 +61,8 @@ julian net start \
 - Monitor `anchors_received_total`, `finality_events_total` and peer counts via Prometheus.
 
 ## Permissionless Mode
-For public growth, run the network without policy gating. See `docs/permissionless_join.md`.
+For the historical public-growth configuration, see the
+[Permissionless Join Guide](permissionless_join.md).
 
 ## Tokenomics (Stake Registry)
 - Fees and rewards are tracked in `stake_registry.json`.
@@ -66,4 +71,5 @@ For public growth, run the network without policy gating. See `docs/permissionle
 
 ## Governance
 - Membership is controlled by governance state (`stake` or `multisig` backends).
-- Use the governance update flow in `README.md` to add/remove members.
+- Use the current CLI help and [Network Operations](ops.md) for governance
+  procedures.

--- a/docs/hyperscale_proof.md
+++ b/docs/hyperscale_proof.md
@@ -1,5 +1,7 @@
 # Hyperscale Seeded-Affine Proof
 
+Status: active proof profile for Power House v0.3.1.
+
 `examples/hyperscale_affine.rs` demonstrates a non-constant sum-check
 certificate over domains far larger than sextillion scale.
 

--- a/docs/mainnet_launch.md
+++ b/docs/mainnet_launch.md
@@ -1,6 +1,11 @@
 # POWER_HOUSE MAINNET LAUNCH – OPERATIONS GUIDE
 Doc version: v0.1.54
 
+> Historical two-boot deployment guide. Do not use it as the v0.3.1 production
+> authority. Current validator and RPC deployment procedures are in
+> [Production RPC Deployment](production_rpc_deployment.md) and
+> [RPC Operations](rpc_operations.md).
+
 This guide promotes your current two‑boot topology (boot1, boot2) to an open, public mainnet without manual peer approvals. It preserves uptime, removes trust boundaries, and keeps the network observable and maintainable.
 
 Contents

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,9 +1,12 @@
 # Power-House Operations Guide
-Doc version: v0.1.54
 
-This guide documents the production-grade deployment flow for the JULIAN network
-nodes and blob service. It assumes explicit manual control (no hidden scripts),
-so every step is auditable.
+Release scope: Power House v0.3.1.
+
+This guide documents the retained boot-node, JULIAN network, and blob-service
+operations in v0.3.1. For the current three-validator native RPC topology and
+public HTTPS edge, use
+[Production RPC Deployment](production_rpc_deployment.md). Commands here
+assume explicit operator control so each change remains auditable.
 
 ## 1. Requirements
 
@@ -182,7 +185,7 @@ python3 scripts/check_rpc.py https://rpc.example.org --expected-chain-id 177155 
 The probe requires working DNS/TLS, consistent `eth_chainId` and
 `net_version`, a valid latest block response, and browser CORS when requested.
 It is an endpoint integrity check, not a substitute for consensus-state audits.
-See `docs/rpc_operations.md`.
+See [RPC Operations](rpc_operations.md).
 
 ## 10.2 External DA publisher (optional)
 

--- a/docs/orbital_observatory.md
+++ b/docs/orbital_observatory.md
@@ -1,5 +1,7 @@
 # MFENX Orbital Observatory
 
+Release surface: Power House v0.3.1.
+
 `mfenx.com` presents Power House as an interactive planetary proof
 observatory. It combines live celestial telemetry, world time, published proof
 artifacts, and browser-side verification in one static deployment.
@@ -24,28 +26,30 @@ City markers and proof-orbit beacons are selectable directly on the globe.
 The globe supports pointer rotation, wheel zoom, touch input, keyboard
 rotation, keyboard zoom, and one-command focus on the selected city.
 
-## Proof orbits
+## Verification modes
 
-The four orbit tracks map to the public verification modes:
+The five instrument modes are:
 
-1. A 70-round constant-polynomial equation replay over field
+1. Browser-native `.pha` and Rootprint core verification, including
+   deterministic fingerprint, branch ID, ordering, and reachability checks.
+2. A 70-round constant-polynomial equation replay over field
    `1,000,000,007`.
-2. A 4,096-round seeded-affine structural replay.
-3. SHA-256 verification of the published `PHSPv1` million-round artifact.
-4. SHA-256 verification of both the `PHSMv1` workload and `PHCPv1`
+3. A 4,096-round seeded-affine structural replay.
+4. SHA-256 verification of the published `PHSPv1` million-round artifact.
+5. SHA-256 verification of both the `PHSMv1` workload and `PHCPv1`
    certificate.
 
 Proof progress is reflected in both the verification dock and the active
 orbital beacon. Successful runs can be shared through the Web Share API or
-copied to the clipboard. The local-file control accepts the published
-`PHSPv1` certificate or a paired `PHSMv1`/`PHCPv1` workload and certificate,
-checks exact byte lengths, and computes the release SHA-256 digests entirely
-in the browser.
+copied to the clipboard. The local-file control accepts `.pha`, Rootprint JSON,
+the published `PHSPv1` certificate, or a paired `PHSMv1`/`PHCPv1` workload and
+certificate. Portable JSON files receive core verification; binary release
+artifacts receive exact-length and SHA-256 verification.
 
 The browser replays provide immediate interactive checks. The canonical Rust
 and Python tooling provides full artifact parsing, transcript validation,
-BLAKE2b workload commitment checks, and algebraic replay as documented in
-`docs/verification_guide.md`.
+BLAKE2b workload commitment checks, and algebraic replay as documented in the
+[Verification Guide](verification_guide.md).
 
 ## Performance
 
@@ -65,8 +69,8 @@ BLAKE2b workload commitment checks, and algebraic replay as documented in
 The static site is stored under `publicpower/` and deployed from the
 `gh-pages` branch. `publicpower/CNAME` maps GitHub Pages to `mfenx.com`.
 
-Release artifacts are bundled under `publicpower/artifacts/` so the browser
-can stream and hash them from the same origin.
+Release artifacts and the canonical Rootprint vector are bundled under
+`publicpower/artifacts/` so the browser can verify them from the same origin.
 
 ## Visual sources
 

--- a/docs/permissionless_join.md
+++ b/docs/permissionless_join.md
@@ -1,5 +1,9 @@
 # Permissionless Join Guide
 
+> Historical public-testnet guide. Do not reuse its bootstrap placeholders or
+> quorum values for production. See [Documentation](README.md) and
+> [Network Operations](ops.md).
+
 This guide enables open community joining without additional infrastructure spend.
 
 ## When To Use

--- a/docs/pha_spec.md
+++ b/docs/pha_spec.md
@@ -2,6 +2,8 @@
 
 ## Status
 
+Normative for Power House v0.3.1.
+
 This document defines the portable Power House Archive v1 JSON format. The
 schema identifier is:
 
@@ -121,3 +123,24 @@ a caller-supplied verifier for external proof semantics.
 
 No Power House workflow is permitted to require EPA verification for core
 validity.
+
+## Conformance
+
+Canonical valid vectors are stored in `conformance/pha-v1`:
+
+- `core-valid.pha`
+- `core-with-epa.pha`
+- `rootprint-valid.json`
+- `manifest.json`
+
+Regenerate and verify them with:
+
+```bash
+cargo run --example pha_conformance_vectors
+PYTHONPATH=sdk/python python3 -m unittest discover -s sdk/python/tests -v
+```
+
+See [Rootprint v1](rootprint.md) for graph identity and
+[SDKs](sdk.md) for cross-language interfaces. Security assumptions and
+mutation behavior are defined in the
+[Provenance Security Model](provenance_security.md).

--- a/docs/prior_art_review.md
+++ b/docs/prior_art_review.md
@@ -1,6 +1,6 @@
 # Prior-Art Review
 
-Status: initial technical review, not an exhaustive novelty opinion.
+Status: active technical review for Power House v0.3.1.
 
 ## Question Under Review
 

--- a/docs/production_rpc_deployment.md
+++ b/docs/production_rpc_deployment.md
@@ -1,5 +1,7 @@
 # Production RPC Deployment
 
+Release scope: Power House v0.3.1.
+
 The retired VPS hosts should not be restored. Replace them with a reproducible
 three-validator deployment whose membership, keys, genesis balances, service
 configuration, and public edge are independently verifiable.

--- a/docs/promotion_pack.md
+++ b/docs/promotion_pack.md
@@ -1,5 +1,8 @@
 # Promotion Pack (Forums + Hackathons)
 
+> Historical campaign material. Verify current bootstrap addresses, policies,
+> quorum values, and program terms before publishing any derivative.
+
 This pack is designed to grow to 1,000+ nodes without paying for more VPS instances.
 
 ## Forum Announcement (Short)
@@ -59,5 +62,5 @@ Deliverables:
 - Uptime window:
 
 ## Links
-- Permissionless join guide: `docs/permissionless_join.md`
-- Community onboarding: `docs/community_onboarding.md`
+- [Permissionless join guide](permissionless_join.md)
+- [Community onboarding](community_onboarding.md)

--- a/docs/provenance_security.md
+++ b/docs/provenance_security.md
@@ -1,0 +1,115 @@
+# Provenance Security Model
+
+Status: active security statement for Power House v0.3.1.
+
+This document defines the integrity boundary for Power House Archive (`.pha`)
+v1, Rootprint v1, and optional external proof attachments.
+
+## Protected Core
+
+A `.pha` core fingerprint commits to:
+
+- the schema identifier;
+- provenance JSON;
+- the embedded Power House protocol identifier;
+- public inputs;
+- the embedded Power House proof payload.
+
+The stored fingerprint and `external_proof_attachments` are excluded from the
+fingerprint projection.
+
+Rootprint branch identity commits to:
+
+- the branch label;
+- sorted parent branch IDs;
+- the carried artifact's `phx_fingerprint`.
+
+Sequence values enforce parent-before-child ordering but do not participate in
+branch identity.
+
+## Integrity Properties
+
+### Core mutation rejection
+
+Changing any fingerprinted `.pha` field without refreshing the fingerprint is
+rejected by `PhaArtifact::verify()`.
+
+### Deterministic identity
+
+Rust, Python, and browser implementations use domain-separated SHA-256 over
+canonical JSON. Canonical objects use lexicographically sorted keys, UTF-8,
+compact encoding, and integer-only JSON numbers.
+
+### EPA isolation
+
+Adding, removing, reordering, or mutating EPA data does not alter:
+
+- `phx_fingerprint`;
+- Rootprint branch IDs;
+- Rootprint equivalence;
+- Rootprint core validity.
+
+EPA payload integrity is checked only through an explicit attachment
+verification operation.
+
+### Graph mutation rejection
+
+Rootprint verification rejects:
+
+- a missing or malformed root;
+- branch map keys that do not match branch IDs;
+- invalid carried `.pha` cores;
+- recalculated branch ID mismatches;
+- unsorted, duplicate, missing, or excessive parents;
+- parent sequence values that do not precede children;
+- branches unreachable from the root.
+
+## Cryptographic Assumptions
+
+Identity security relies on SHA-256 collision and second-preimage resistance.
+Sparse transcript and workload formats additionally use their documented
+BLAKE2b-256 domains. Signature and quorum behavior in the optional network
+feature uses the algorithms and policy assumptions documented in the JULIAN
+protocol and operations guides.
+
+## Verification Responsibility
+
+`.pha` core verification establishes deterministic artifact integrity. The
+meaning of an opaque protocol-specific proof remains the responsibility of the
+protocol identified by `embedded_proof.protocol`.
+
+EPA integrity verification establishes that an attachment payload matches its
+declared digest. Cryptographic interpretation of an external proof system
+requires a caller-supplied verifier through
+`verify_external_proof_attachments_with`.
+
+## Conformance And Mutation Tests
+
+The Rust integration suite and Python SDK consume `conformance/pha-v1`.
+Coverage includes:
+
+- valid core-only artifacts;
+- valid artifacts carrying EPA;
+- valid fork and merge graphs;
+- core-field mutation rejection;
+- EPA mutation isolation;
+- matching Rust and Python fingerprints and branch IDs;
+- complete CLI navigation, fork, merge, and verification workflows.
+
+Run:
+
+```bash
+cargo test --test provenance_protocol --test rootprint_cli
+PYTHONPATH=sdk/python python3 -m unittest discover -s sdk/python/tests -v
+```
+
+The browser verifier at `mfenx.com` independently recalculates the published
+Rootprint vector's core fingerprints, branch IDs, ordering, and reachability.
+
+## Related Documents
+
+- [Power House Archive v1](pha_spec.md)
+- [Rootprint v1](rootprint.md)
+- [SDKs](sdk.md)
+- [Verification Guide](verification_guide.md)
+- [Sparse Certificate Security Model](security_model.md)

--- a/docs/research_protocol.md
+++ b/docs/research_protocol.md
@@ -1,5 +1,7 @@
 # Research Protocol
 
+Status: active research and evidence protocol for Power House v0.3.1.
+
 This document turns Power-House development into a falsifiable research
 program. Scale demonstrations remain useful, but exponent size alone is not a
 research contribution.

--- a/docs/roadmap_v0.1.54.md
+++ b/docs/roadmap_v0.1.54.md
@@ -1,5 +1,9 @@
 # Power-House v0.1.54 Design Plan
 
+> Historical design record. This plan is retained for release traceability and
+> does not describe the current v0.3.1 implementation. See
+> [Documentation](README.md).
+
 Objective
 - Deliver a verifiable, adversarially hardened core that is closer to a coordination primitive than a product feature set.
 - Keep the implementation auditable and testable: no hidden magic, no opaque dependencies.

--- a/docs/rootprint.md
+++ b/docs/rootprint.md
@@ -1,5 +1,7 @@
 # Rootprint v1
 
+Status: normative for Power House v0.3.1.
+
 Rootprint is the primary Power House provenance workflow. It is a deterministic
 directed acyclic graph whose nodes carry `.pha` artifacts and whose edges record
 fork and merge ancestry.
@@ -16,6 +18,26 @@ External proof attachments are never inputs to branch IDs, graph verification,
 navigation, equivalence, forking, or merging. A branch can carry EPA because
 its `.pha` artifact can carry EPA, but Rootprint does not require or interpret
 it.
+
+## Document model
+
+A Rootprint document contains:
+
+| Field | Meaning |
+| --- | --- |
+| `schema` | Must equal `power-house/rootprint/v1`. |
+| `root_branch` | Deterministic ID of the unique root branch. |
+| `branches` | Object keyed by deterministic branch ID. |
+
+Each branch contains:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Domain-separated deterministic branch ID. |
+| `label` | Human-readable selector, limited to 128 characters. |
+| `sequence` | Parent-before-child ordering value. |
+| `parents` | Zero IDs for root, one for fork, two sorted IDs for merge. |
+| `artifact` | A core-valid `.pha` artifact. |
 
 ## Rust interface
 
@@ -84,6 +106,9 @@ julian rootprint verify experiment.rootprint.json
 Selectors resolve exact branch IDs, unique ID prefixes, or unique labels.
 `rootprint verify` is always a Power House core operation.
 
+`julian attach-external-proof` is a separate optional operation. It may add EPA
+transport data to a `.pha` artifact without changing its `phx_fingerprint`.
+
 ## Deterministic branch ID
 
 Every branch ID is domain-separated SHA-256 over canonical JSON with
@@ -109,3 +134,21 @@ part of branch identity.
 EPA integrity can be checked explicitly through
 `Rootprint::verify_external_proof_attachments()`. It is not called by
 `Rootprint::verify()` and is not part of the standard CLI workflow.
+
+## Verification invariants
+
+Core verification requires:
+
+1. the Rootprint schema is supported;
+2. the root exists, has sequence `0`, and has no parents;
+3. every branch map key equals its stored branch ID;
+4. every carried `.pha` artifact passes core verification;
+5. every branch ID recalculates exactly;
+6. parent lists are sorted, unique, and contain at most two IDs;
+7. every parent has a lower sequence than its child;
+8. every branch is reachable from the root.
+
+Canonical vectors are published under `conformance/pha-v1`.
+
+Security assumptions and mutation behavior are defined in the
+[Provenance Security Model](provenance_security.md).

--- a/docs/rpc_operations.md
+++ b/docs/rpc_operations.md
@@ -1,5 +1,7 @@
 # Power-House RPC Operations
 
+Release scope: Power House v0.3.1.
+
 Power-House exposes a native-transfer JSON-RPC lane whose blocks and account
 state are finalized by the configured validator quorum. Chain ID `177155` is
 the default production identity.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,6 +1,6 @@
 # SDKs
 
-Power House v0.3.0 ships matching Rust and zero-dependency Python interfaces
+Power House v0.3.1 ships matching Rust and zero-dependency Python interfaces
 for `.pha` and Rootprint v1.
 
 ## Rust
@@ -21,6 +21,9 @@ graph.verify()?;
 ```
 
 ## Python
+
+The Python package is distributed in this repository and in the crate source
+archive. Install it from a checkout or extracted crate:
 
 ```bash
 python3 -m pip install ./sdk/python
@@ -43,3 +46,26 @@ The default Python namespace contains no EPA functions. Optional attachment
 transport requires an explicit import from `power_house.external`.
 
 Both implementations consume the vectors in `conformance/pha-v1`.
+
+## Core API mapping
+
+| Operation | Rust | Python |
+| --- | --- | --- |
+| Create `.pha` | `PhaArtifact::new` | `create_artifact` |
+| Verify `.pha` core | `PhaArtifact::verify` | `verify_artifact` |
+| Create Rootprint | `Rootprint::new` or `prove_with_rootprint!` | `new_rootprint` |
+| Navigate | `Rootprint::navigate` | `navigate` |
+| Fork | `Rootprint::fork` | `fork` |
+| Merge | `Rootprint::merge` | `merge` |
+| Compare core identity | `Rootprint::equivalent` | `equivalent` |
+| Verify graph | `Rootprint::verify` | `verify_rootprint` |
+
+## Conformance
+
+```bash
+cargo run --example pha_conformance_vectors
+PYTHONPATH=sdk/python python3 -m unittest discover -s sdk/python/tests -v
+```
+
+The suite verifies matching fingerprints and branch IDs, rejects core
+mutations, and confirms that EPA mutation remains outside core validity.

--- a/docs/security_model.md
+++ b/docs/security_model.md
@@ -1,5 +1,7 @@
 # Sparse Certificate Security Model
 
+Status: active security statement for Power House v0.3.1 sparse formats.
+
 This document defines what `PHSPv1`, `PHSMv1`, and `PHCPv1` establish and what
 they do not establish.
 

--- a/docs/sextillion_proof.md
+++ b/docs/sextillion_proof.md
@@ -1,5 +1,7 @@
 # Sextillion-Scale Verification Certificate
 
+Status: active proof profile for Power House v0.3.1.
+
 Power-House can verify a sum-check claim over a domain larger than one
 sextillion points without enumerating the domain.
 
@@ -57,4 +59,5 @@ scale, while the proof and verification work are logarithmic in the number of
 points for this polynomial family.
 
 For a non-constant structured computation far beyond sextillion scale, see
-`docs/hyperscale_proof.md` and `cargo run --example hyperscale_affine`.
+[Hyperscale Seeded-Affine Proof](hyperscale_proof.md) and
+`cargo run --example hyperscale_affine`.

--- a/docs/sparse_record.md
+++ b/docs/sparse_record.md
@@ -1,5 +1,7 @@
 # Public Sparse Computation Certificate
 
+Status: active format guide for Power House v0.3.1.
+
 Power-House now includes an event-driven sum-check prover for a public seeded
 sparse multilinear polynomial:
 
@@ -86,6 +88,6 @@ The verifier remains linear in the number of rounds. It is independent of the
 ## Scope
 
 This certificate verifies a public, compactly described polynomial. The
-`PHSMv1`/`PHCPv1` workflow in `docs/committed_workload.md` extends it to
-separately stored external public data. Neither format yet provides a succinct
+[`PHSMv1`/`PHCPv1` workflow](committed_workload.md) extends it to separately
+stored external public data. Neither format yet provides a succinct
 multilinear polynomial opening or a hidden-witness argument.

--- a/docs/tokenomics.md
+++ b/docs/tokenomics.md
@@ -1,5 +1,9 @@
 # Tokenomics (Phase 3)
 
+> Historical Phase 3 economic configuration. It is not a current offer,
+> issuance schedule, or production policy. Runtime behavior is defined by the
+> deployed registry and policy files.
+
 This document defines fee flow and reward splitting for Power-House anchors.
 
 ## Roles

--- a/docs/training_binder.md
+++ b/docs/training_binder.md
@@ -1,6 +1,10 @@
 # Training Binder — Power House Operator Packet
 Doc version: v0.1.54
 
+> Historical training snapshot. This binder preserves v0.1.54 exercises and is
+> not the current v0.3.1 operator runbook. See [Documentation](README.md) and
+> [Network Operations](ops.md).
+
 This binder distills the mandatory drills called out across `book_of_power.md`. Work through each section, initial in the signature block, and archive the completed packet with your ledger logs.
 
 ## 1. Field Prime Exercises *(Book refs: Chapter II, §§01–41)*

--- a/docs/verification_guide.md
+++ b/docs/verification_guide.md
@@ -1,6 +1,6 @@
 # Verification Guide
 
-This guide reproduces every large-domain proof mode in `power_house` v0.3.0.
+This guide reproduces the Power House v0.3.1 provenance and proof workflows.
 
 ## Requirements
 
@@ -20,7 +20,35 @@ cargo clippy --all-targets --all-features -- -D warnings
 python3 -m py_compile scripts/*.py
 ```
 
-## 2. Verify more than one sextillion points
+## 2. Verify `.pha` and Rootprint
+
+Regenerate the canonical artifacts:
+
+```bash
+cargo run --example pha_conformance_vectors
+git diff --exit-code -- \
+  conformance/pha-v1 \
+  publicpower/artifacts/rootprint-valid.json
+```
+
+Run Rust and Python core-independence tests:
+
+```bash
+cargo test --test provenance_protocol --test rootprint_cli
+PYTHONPATH=sdk/python python3 -m unittest discover -s sdk/python/tests -v
+```
+
+Run the library workflow:
+
+```bash
+cargo run --example rootprint_workflow
+```
+
+The tests require all Power House core mutations to reject. EPA payload
+mutation must preserve `.pha` and Rootprint core validity while failing the
+separate explicit EPA integrity check.
+
+## 3. Verify more than one sextillion points
 
 ```bash
 cargo run --release --example sextillion_verify
@@ -29,7 +57,7 @@ cargo run --release --example sextillion_verify
 This proves the Boolean-hypercube sum of a constant polynomial over `2^70`
 points. The proof and verifier each process 70 rounds.
 
-## 3. Verify a seeded non-constant polynomial
+## 4. Verify a seeded non-constant polynomial
 
 ```bash
 cargo run --release --example hyperscale_affine
@@ -39,7 +67,7 @@ The public seed defines an affine multilinear polynomial over `2^4096` points.
 The verifier derives the same coefficients, replays every Fiat-Shamir round,
 and rejects a different seed or modified round.
 
-## 4. Generate a million-round sparse certificate
+## 5. Generate a million-round sparse certificate
 
 ```bash
 cargo run --release --example sparse_record
@@ -51,7 +79,7 @@ python3 scripts/verify_sparse_certificate.py \
 The default certificate has one million rounds and describes a public seeded
 sparse polynomial over `2^1,000,000` points.
 
-## 5. Bind a proof to external data
+## 6. Bind a proof to external data
 
 ```bash
 cargo run --release --example committed_workload -- generate
@@ -76,7 +104,7 @@ python3 scripts/test_sparse_verifier.py
 The test consumes the canonical `conformance/v1` files, validates their
 manifest, and requires rejection after XOR-mutating every individual byte.
 
-## 6. Confirm tamper rejection
+## 7. Confirm tamper rejection
 
 ```bash
 cp target/external_interaction_model.phsm /tmp/tampered.phsm

--- a/publicpower/index.html
+++ b/publicpower/index.html
@@ -233,7 +233,7 @@
       <div class="evaluation-links">
         <a href="https://github.com/JROChub/power_house/blob/main/docs/verification_guide.md">REPRODUCE</a>
         <a href="https://github.com/JROChub/power_house/blob/main/docs/security_model.md">SECURITY MODEL</a>
-        <a href="https://crates.io/crates/power_house">CRATE v0.3.0</a>
+        <a href="https://crates.io/crates/power_house">CRATE v0.3.1</a>
       </div>
     </aside>
 
@@ -274,7 +274,7 @@
         <div><span>CLAIM</span><b id="claim-value">WAITING</b></div>
         <div><span>DIGEST</span><b id="digest-value">PENDING</b></div>
         <div><span>MODE</span><b id="mode-value">ROOTPRINT</b></div>
-        <div><span>RELEASE</span><b>v0.3.0</b></div>
+        <div><span>RELEASE</span><b>v0.3.1</b></div>
       </div>
     </section>
 

--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.egg-info/
+build/
+dist/
+.pytest_cache/

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,5 +1,7 @@
 # Power House Python SDK
 
+Version: 0.3.1
+
 The default `power_house` namespace implements `.pha` v1 and Rootprint v1
 without requiring or interpreting external proof attachments.
 
@@ -20,4 +22,10 @@ EPA transport helpers are deliberately separated:
 
 ```python
 from power_house.external import attach_external_proof, verify_external_attachments
+```
+
+Run the shared conformance suite from the repository root:
+
+```bash
+PYTHONPATH=sdk/python python3 -m unittest discover -s sdk/python/tests -v
 ```

--- a/sdk/python/power_house/__init__.py
+++ b/sdk/python/power_house/__init__.py
@@ -34,4 +34,4 @@ __all__ = [
     "verify_rootprint",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "power-house-sdk"
-version = "0.3.0"
+version = "0.3.1"
 description = "Zero-dependency Python SDK for Power House Archive and Rootprint v1"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,62 +1,94 @@
 #![deny(missing_docs)]
 
-//! The design philosophy underlying `power_house` is pedagogical, yet mathematically rigorous.
-//! Each module encapsulates a discrete concept in modern computational complexity theory,
-//! illustrating how modest abstractions compose into a cohesive proof infrastructure.
+//! Deterministic verification, portable proof provenance, and optional quorum
+//! networking.
 //!
-//! This crate aspires to bridge gaps between theoretical exposition and practical engineering,
-//! serving both as a didactic resource and a foundation for future cryptographic research.
-//! # power_house
+//! Power House combines five interoperable layers:
 //!
-//! **Power-House** is a Rust crate that showcases a set of cryptographic
-//! and verification primitives inspired by interactive proof systems and the
-//! sum-check protocol. The goal of this crate is to
-//! demonstrate how one can build powerful proof systems and consensus logic
-//! with a minimal dependency surface while still leaning on modern hash
-//! primitives for tamper evidence.
+//! - [`provenance`] defines Power House Archive (`.pha`) and Rootprint v1.
+//! - [`sumcheck`] implements dense, streaming, constant, and seeded-affine
+//!   sum-check workflows.
+//! - [`sparse_sumcheck`] implements stable seeded and commitment-bound sparse
+//!   certificate formats.
+//! - [`julian`] records proof transcripts, anchors them, and reconciles quorum
+//!   state.
+//! - [`net`] adds signed libp2p transport, data availability, governance, and
+//!   quorum-finalized native RPC when the `net` feature is enabled.
 //!
-//! ## Features
+//! # Power House Archive
 //!
-//! * **Finite field arithmetic** via the [`Field`](field/struct.Field.html) type.
-//! * **Sum-check demonstration**: the [`sumcheck`](sumcheck/index.html) module
-//!   contains functions to compute the true sum of a small bivariate polynomial
-//!   over the Boolean hypercube, build a one-shot claim, and verify it. Security
-//!   depends on the selected field, round count, transcript model, and protocol.
-//! * **Pseudorandom number generator (PRNG)**: the [`prng`](prng/index.html)
-//!   module exposes a compact BLAKE2b-256 expander that derives deterministic
-//!   Fiat–Shamir challenges from transcripts.  It serves as a stand-in for a
-//!   verifiable random function (VRF) when exploring protocol blueprints.
-//! * **Byzantine-fault-tolerant consensus**: the [`consensus`](consensus/index.html)
-//!   module provides a trivial consensus primitive that takes a set of binary
-//!   votes and returns whether the threshold has been met.  It is intended as
-//!   a pedagogical example of how one might aggregate prover responses.
-//! * **JULIAN protocol blueprint**: the [`julian`](julian/index.html) module
-//!   outlines, through documentation and type stubs, how one could combine
-//!   interactive proofs, VRF randomness, consensus and provability logic
-//!   into a globally verifiable proof ledger. It is a protocol blueprint and
-//!   does not by itself implement a complete production ledger.
+//! A [`provenance::PhaArtifact`] binds core proof data and provenance to a
+//! deterministic `phx_fingerprint`. Optional external proof attachments are
+//! transported with the artifact but do not alter its Power House core
+//! identity.
 //!
-//! ## Usage
+//! ```
+//! use power_house::provenance::PhaArtifact;
+//! use serde_json::json;
 //!
-//! The following example demonstrates how to compute and verify a sum-check
-//! claim for the demo polynomial \f$\,f(x_1,x_2) = x_1 + x_2 + 2 x_1 x_2\,\) modulo a
-//! small prime \f$p\,\) using this crate:
-//!
-//! ```rust
-//! use power_house::{Field, sumcheck::SumClaim};
-//!
-//! // Choose a prime field of order 101.
-//! let field = Field::new(101);
-//!
-//! // Prover creates an honest claim with default round count k=8.
-//! let claim = SumClaim::prove_demo(&field, 8);
-//! // The verifier checks that the claim is valid.
-//! assert!(claim.verify_demo());
+//! let artifact = PhaArtifact::new(
+//!     json!({"producer": "example"}),
+//!     "power-house/example/v1",
+//!     json!({"claim": 7}),
+//!     json!({"accepted": true}),
+//! )?;
+//! artifact.verify()?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
-//! The crate can be extended with richer protocols by building on these
-//! primitives.  It is intentionally minimal and does not offer a complete
-//! blockchain or proof ledger implementation.
+//! # Rootprint
+//!
+//! [`provenance::Rootprint`] is a deterministic directed acyclic graph of
+//! `.pha` artifacts. The [`prove_with_rootprint!`] macro is the recommended
+//! construction interface.
+//!
+//! ```
+//! use power_house::{prove_with_rootprint, provenance::PhaArtifact};
+//! use serde_json::json;
+//!
+//! let artifact = PhaArtifact::new(
+//!     json!({"source": "rootprint-example"}),
+//!     "power-house/example/v1",
+//!     json!({"claim": 11}),
+//!     json!({"accepted": true}),
+//! )?;
+//! let graph = prove_with_rootprint!(label: "main", artifact: artifact)?;
+//! graph.verify()?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! # Structured sum-check
+//!
+//! Closed-form and seeded proof constructors operate on compact algebraic
+//! descriptions without allocating the expanded Boolean hypercube.
+//!
+//! ```
+//! use power_house::{Field, GeneralSumProof};
+//!
+//! let field = Field::new(1_000_000_007);
+//! let proof = GeneralSumProof::prove_seeded_affine(
+//!     4096,
+//!     &field,
+//!     b"public reproducible workload",
+//! );
+//! assert!(proof.verify_seeded_affine(
+//!     &field,
+//!     b"public reproducible workload",
+//! ));
+//! ```
+//!
+//! # Feature flags
+//!
+//! - `default`: proof, provenance, transcript, and sparse-certificate APIs.
+//! - `net`: networking, migration commands, data availability, governance,
+//!   staking, and native JSON-RPC.
+//!
+//! # Specifications and guides
+//!
+//! The repository contains the normative `.pha` and Rootprint specifications,
+//! cross-language conformance vectors, provenance and sparse security models,
+//! verification guide, and operational runbooks. See the
+//! [documentation index](https://github.com/JROChub/power_house/blob/main/docs/README.md).
 
 pub mod consensus;
 mod data;

--- a/src/rollup.rs
+++ b/src/rollup.rs
@@ -184,7 +184,7 @@ pub struct ZkRollupProof {
     pub proof: Vec<u8>,
     /// Public inputs: prev||next||tx_root||share_root (4 x 32 bytes LE).
     pub public_inputs: Vec<u8>,
-    /// Merkle path siblings (JSON-serialized Vec<MerkleSibling>).
+    /// Merkle path siblings (JSON-serialized `Vec<MerkleSibling>`).
     pub merkle_path: Vec<u8>,
 }
 

--- a/src/sumcheck.rs
+++ b/src/sumcheck.rs
@@ -85,7 +85,7 @@ impl SumClaim {
     /// Proves the sum of the demo polynomial without interaction.
     ///
     /// This function constructs an honest claim for the demo polynomial
-    /// defined by [`f_demo`](crate::sumcheck::f_demo) over the field with
+    /// defined by [`f_demo`] over the field with
     /// modulus `field.modulus()`.  It deterministically derives a
     /// randomness seed from the transcript to choose the challenge `r1`
     /// and the final checks `r2_i`.  The soundness error is bounded


### PR DESCRIPTION
## What changed

- rebuilds the GitHub and crates.io README around Power House Archive, Rootprint, verification profiles, SDKs, and current operations
- replaces the legacy rustdoc landing page with current `.pha`, Rootprint, sum-check, sparse proof, and feature documentation
- adds an authoritative documentation index and a dedicated provenance security model
- updates active protocol, SDK, verification, Observatory, RPC, and operations guides
- marks retained v0.1.x and Phase 3 material as historical
- updates crate metadata, Python SDK metadata, release notes, and public release labels to v0.3.1
- configures docs.rs to build all features and makes rustdoc warnings fatal in CI

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- `cargo test --all-targets --locked`
- `cargo test --all-targets --features net --locked`
- `cargo publish --dry-run --locked --allow-dirty`
- Rust/Python conformance regeneration and SDK tests
- CLI, RPC deployment, and three-replica native finality tests
- local Markdown link validation
- generated rustdoc visual inspection