### PR TITLE
Release v0.3.3 docs and Observatory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
             infra/ops/alert.sh
           python3 -m py_compile \
             scripts/check_release_consistency.py \
+            scripts/check_rustdoc_links.py \
             scripts/rpc_load_test.py \
+            scripts/test_observatory_contract.py \
             infra/ops/healthcheck.py \
             infra/monitoring/alert_receiver.py \
             infra/monitoring/status_api.py
@@ -54,7 +56,9 @@ jobs:
       - name: Documentation
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo doc --all-features --no-deps
+        run: |
+          cargo doc --all-features --no-deps
+          python3 scripts/check_rustdoc_links.py
 
       - name: Test default targets
         run: cargo test --all-targets --locked
@@ -110,7 +114,10 @@ jobs:
         run: python3 scripts/test_sparse_verifier.py
 
       - name: Browser artifact stream regression
-        run: node scripts/test_observatory_stream.mjs
+        run: |
+          node --check publicpower/app.js
+          node scripts/test_observatory_stream.mjs
+          python3 scripts/test_observatory_contract.py
 
       - name: Soundness budget checks
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "power_house"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "power_house"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["MFENX LLC"]
 description = "Deterministic proofs, portable .pha provenance, Rootprint graphs, and optional quorum networking."
@@ -41,6 +41,7 @@ include = [
   "scripts/benchmark_v030.py",
   "scripts/check_rpc.py",
   "scripts/check_release_consistency.py",
+  "scripts/check_rustdoc_links.py",
   "scripts/deploy_monitoring_stack.sh",
   "scripts/deploy_rpc_cluster.sh",
   "scripts/digitalocean_rpc_preflight.sh",
@@ -51,6 +52,7 @@ include = [
   "scripts/test_digitalocean_provision.sh",
   "scripts/test_generate_rpc_cluster.py",
   "scripts/test_native_rpc_cluster.sh",
+  "scripts/test_observatory_contract.py",
   "scripts/test_rpc_check.py",
   "scripts/test_sparse_verifier.py",
   "scripts/verify_sparse_certificate.py",

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN cargo build --release --locked --features net --bin julian
 
 FROM debian:bookworm-slim
-ARG POWER_HOUSE_VERSION=0.3.2
+ARG POWER_HOUSE_VERSION=0.3.3
 LABEL org.opencontainers.image.title="Power House" \
   org.opencontainers.image.version="${POWER_HOUSE_VERSION}" \
   org.opencontainers.image.source="https://github.com/JROChub/power_house"

--- a/JULIAN_PROTOCOL.md
+++ b/JULIAN_PROTOCOL.md
@@ -1,5 +1,5 @@
 MFENX Power-House Network: The JULIAN Protocol Network
-Version 0.3.2 - June 2026
+Version 0.3.3 - June 2026
 
 
 # JULIAN Protocol: Proof-Transparent Consensus via Folding-Derived Anchors

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ combines structured sum-check proofs, portable `.pha` artifacts, Rootprint
 proof-history graphs, commitment-bound sparse workloads, transcript anchoring,
 and an optional quorum network.
 
-Current release: **v0.3.2**
+Current release: **v0.3.3**
 
 The primary workflow is **Power House + Rootprint**:
 
@@ -117,20 +117,21 @@ The complete procedure and expected rejection behavior are documented in the
 
 ## Primary Rust APIs
 
-- [`PhaArtifact`](https://docs.rs/power_house/latest/power_house/provenance/struct.PhaArtifact.html):
+- [`PhaArtifact`](https://docs.rs/power_house/latest/power_house/provenance/pha/struct.PhaArtifact.html):
   portable Power House core identity.
-- [`Rootprint`](https://docs.rs/power_house/latest/power_house/provenance/struct.Rootprint.html):
+- [`Rootprint`](https://docs.rs/power_house/latest/power_house/provenance/rootprint/struct.Rootprint.html):
   deterministic proof-history branching and verification.
-- `prove_with_rootprint!`: recommended provenance-aware construction interface.
-- [`GeneralSumProof`](https://docs.rs/power_house/latest/power_house/struct.GeneralSumProof.html):
+- [`prove_with_rootprint!`](https://docs.rs/power_house/latest/power_house/macro.prove_with_rootprint.html):
+  recommended provenance-aware construction interface.
+- [`GeneralSumProof`](https://docs.rs/power_house/latest/power_house/sumcheck/struct.GeneralSumProof.html):
   dense, streaming, constant, and seeded-affine sum-check.
-- [`SeededSparseProof`](https://docs.rs/power_house/latest/power_house/struct.SeededSparseProof.html):
+- [`SeededSparseProof`](https://docs.rs/power_house/latest/power_house/sparse_sumcheck/struct.SeededSparseProof.html):
   stable `PHSPv1` certificates.
-- [`CommittedSparsePolynomial`](https://docs.rs/power_house/latest/power_house/struct.CommittedSparsePolynomial.html)
+- [`CommittedSparsePolynomial`](https://docs.rs/power_house/latest/power_house/sparse_sumcheck/struct.CommittedSparsePolynomial.html)
   and
-  [`CommittedSparseProof`](https://docs.rs/power_house/latest/power_house/struct.CommittedSparseProof.html):
+  [`CommittedSparseProof`](https://docs.rs/power_house/latest/power_house/sparse_sumcheck/struct.CommittedSparseProof.html):
   external workload binding.
-- [`ProofLedger`](https://docs.rs/power_house/latest/power_house/struct.ProofLedger.html):
+- [`ProofLedger`](https://docs.rs/power_house/latest/power_house/julian/struct.ProofLedger.html):
   transcript logs, anchors, and quorum reconciliation.
 
 ## Python SDK

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,33 @@
 # Release Notes
 
+## v0.3.3 - 2026-06-13
+
+### Documentation
+- Corrected every Primary Rust API link to the defining rustdoc module so the
+  GitHub and crates.io README links resolve to populated docs.rs item pages.
+- Added a direct rustdoc link for the `prove_with_rootprint!` macro.
+- Added a generated-document validation gate that rejects missing, empty, or
+  noncanonical README API targets before release.
+
+### Orbital Observatory
+- Rebuilt the public instrument around a brighter NASA day/night Earth,
+  proof-reactive point shell, selected-city signal geometry, and animated
+  routes between the three production validator regions.
+- Added live public RPC state, block height, validator count, and peer count to
+  the primary control surface.
+- Added explicit focus, network, zoom, reset, sound, and motion controls plus
+  direct URL state for proof mode, city, time offset, and open drawer.
+- Expanded the Observatory with Amsterdam, a solar-position track, and
+  selectable `sfo3`, `nyc3`, and `ams3` quorum controls.
+- Added a CI contract test for all browser control bindings and immutable
+  Rootprint, PHSPv1, PHSMv1, and PHCPv1 artifact sizes and hashes.
+
+### Release Governance
+- Decoupled the active software release from historical network benchmark
+  identity, preserving measured v0.3.2 results without relabeling them.
+- Synchronized Rust, Python, container, website, network, and operator-facing
+  release labels for v0.3.3.
+
 ## v0.3.2 - 2026-06-12
 
 ### Public Network

--- a/configs/network.json
+++ b/configs/network.json
@@ -7,7 +7,8 @@
     "name": "JULIAN",
     "symbol": "JULIAN"
   },
-  "release": "0.3.2",
+  "release": "0.3.3",
+  "benchmarkReport": "benchmarks/v0.3.2/rpc-report.json",
   "rpc": {
     "canonicalUrl": "https://rpc.mfenx.com",
     "chainListUrl": "https://rpc.mfenx.com",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   node:
-    image: ghcr.io/jrochub/power_house:0.3.2
+    image: ghcr.io/jrochub/power_house:0.3.3
     build: .
     command:
       [

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Power House Documentation
 
-This index is the authoritative map for Power House v0.3.2 documentation.
+This index is the authoritative map for Power House v0.3.3 documentation.
 
 ## Start Here
 

--- a/docs/committed_workload.md
+++ b/docs/committed_workload.md
@@ -1,6 +1,6 @@
 # Externally Committed Sparse Workload
 
-Status: active format guide for Power House v0.3.2.
+Status: active format guide for Power House v0.3.3.
 
 Power-House can now bind a sum-check certificate to a separately supplied
 sparse polynomial file.

--- a/docs/hyperscale_proof.md
+++ b/docs/hyperscale_proof.md
@@ -1,6 +1,6 @@
 # Hyperscale Seeded-Affine Proof
 
-Status: active proof profile for Power House v0.3.2.
+Status: active proof profile for Power House v0.3.3.
 
 `examples/hyperscale_affine.rs` demonstrates a non-constant sum-check
 certificate over domains far larger than sextillion scale.

--- a/docs/incident_response.md
+++ b/docs/incident_response.md
@@ -1,6 +1,6 @@
 # MFENX Incident Response
 
-Release scope: Power House v0.3.2.
+Release scope: Power House v0.3.3.
 
 ## Severity
 

--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -1,6 +1,6 @@
 # MFENX Network Load Testing
 
-Release scope: Power House v0.3.2.
+Release scope: Power House v0.3.3.
 
 Run read-only public RPC tests before transaction tests. Never direct an
 unbounded load generator at production.

--- a/docs/network_roadmap.md
+++ b/docs/network_roadmap.md
@@ -1,6 +1,6 @@
 # MFENX Stable Public Network Roadmap
 
-Release scope: Power House v0.3.2.
+Release scope: Power House v0.3.3.
 
 The target is a public network that fails predictably, recovers automatically,
 and exposes enough evidence for operators and users to determine its state.

--- a/docs/node_operator.md
+++ b/docs/node_operator.md
@@ -1,6 +1,6 @@
 # MFENX Node Operator Guide
 
-Release scope: Power House v0.3.2.
+Release scope: Power House v0.3.3.
 
 This guide starts a public observer. Validator admission additionally requires
 a consensus identity approved by the active membership policy.
@@ -19,14 +19,14 @@ unless a firewall and authenticated reverse proxy explicitly protect them.
 ## Install
 
 ```bash
-cargo install power_house --version 0.3.2 --features net --locked
+cargo install power_house --version 0.3.3 --features net --locked
 julian --version
 ```
 
 Or use the release container:
 
 ```bash
-docker pull ghcr.io/jrochub/power_house:0.3.2
+docker pull ghcr.io/jrochub/power_house:0.3.3
 ```
 
 ## Create An Identity

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,9 +1,9 @@
 # Power-House Operations Guide
 
-Release scope: Power House v0.3.2.
+Release scope: Power House v0.3.3.
 
 This guide documents the retained boot-node, JULIAN network, and blob-service
-operations in v0.3.2. For the current three-validator native RPC topology and
+operations in v0.3.3. For the current three-validator native RPC topology and
 public HTTPS edge, use
 [Production RPC Deployment](production_rpc_deployment.md). Commands here
 assume explicit operator control so each change remains auditable.

--- a/docs/orbital_observatory.md
+++ b/docs/orbital_observatory.md
@@ -1,6 +1,6 @@
 # MFENX Orbital Observatory
 
-Release surface: Power House v0.3.2.
+Release surface: Power House v0.3.3.
 
 `mfenx.com` presents Power House as an interactive planetary proof
 observatory. It combines live celestial telemetry, world time, published proof
@@ -20,11 +20,26 @@ The astronomy model provides:
 - solar altitude, sunrise, and sunset for each indexed city,
 - lunar phase and illumination,
 - an adjustable 48-hour celestial timeline,
-- 18 searchable IANA time-zone clocks.
+- 19 searchable IANA time-zone clocks,
+- an altitude-position solar track,
+- live LAX MFENX RPC block, validator, and peer telemetry,
+- selectable `sfo3`, `nyc3`, and `ams3` regional quorum controls.
 
 City markers and proof-orbit beacons are selectable directly on the globe.
 The globe supports pointer rotation, wheel zoom, touch input, keyboard
-rotation, keyboard zoom, and one-command focus on the selected city.
+rotation, keyboard zoom, explicit zoom controls, orbital reset, and
+one-command focus on the selected city. The active city adds a surface halo
+and radial signal beam. Production validator regions are connected by animated
+great-circle routes.
+
+The scene also renders a proof-reactive point shell and field rings. Their
+color follows the selected proof mode, while their density and scale respond
+to live verification progress. URL parameters can open a selected mode, city,
+time offset, or drawer directly:
+
+```text
+/?mode=affine&city=SFO&time=6&panel=observatory
+```
 
 ## Verification modes
 
@@ -63,6 +78,10 @@ BLAKE2b workload commitment checks, and algebraic replay as documented in the
 - Exact artifact-length checks reject truncated or expanded release data
   before hashing.
 - Date and time formatters are cached per IANA zone.
+- The public status feed refreshes every 15 seconds without blocking local
+  proof verification.
+- CI validates every control-to-DOM binding and recomputes the size and
+  SHA-256 digest of all four bundled public artifacts.
 
 ## Deployment
 

--- a/docs/pha_spec.md
+++ b/docs/pha_spec.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Normative for Power House v0.3.2.
+Normative for Power House v0.3.3.
 
 This document defines the portable Power House Archive v1 JSON format. The
 schema identifier is:

--- a/docs/prior_art_review.md
+++ b/docs/prior_art_review.md
@@ -1,6 +1,6 @@
 # Prior-Art Review
 
-Status: active technical review for Power House v0.3.2.
+Status: active technical review for Power House v0.3.3.
 
 ## Question Under Review
 

--- a/docs/production_rpc_deployment.md
+++ b/docs/production_rpc_deployment.md
@@ -1,6 +1,6 @@
 # LAX MFENX RPC Production Deployment
 
-Release scope: Power House v0.3.2.
+Release scope: Power House v0.3.3.
 
 The retired VPS hosts should not be restored. Replace them with a reproducible
 three-validator deployment whose membership, keys, genesis balances, service
@@ -149,7 +149,7 @@ restarts one validator at a time, waits for RPC health, verifies
 Allow validator-tag traffic to TCP `9090`, `9100`, and `9101`, then run:
 
 ```bash
-POWER_HOUSE_RELEASE=0.3.2 \
+POWER_HOUSE_RELEASE=0.3.3 \
 SSH_OPTS="-F /dev/null -o StrictHostKeyChecking=accept-new" \
 scripts/deploy_monitoring_stack.sh \
   root@<validator-1-ipv4> \

--- a/docs/provenance_security.md
+++ b/docs/provenance_security.md
@@ -1,6 +1,6 @@
 # Provenance Security Model
 
-Status: active security statement for Power House v0.3.2.
+Status: active security statement for Power House v0.3.3.
 
 This document defines the integrity boundary for Power House Archive (`.pha`)
 v1, Rootprint v1, and optional external proof attachments.

--- a/docs/research_protocol.md
+++ b/docs/research_protocol.md
@@ -1,6 +1,6 @@
 # Research Protocol
 
-Status: active research and evidence protocol for Power House v0.3.2.
+Status: active research and evidence protocol for Power House v0.3.3.
 
 This document turns Power-House development into a falsifiable research
 program. Scale demonstrations remain useful, but exponent size alone is not a

--- a/docs/rootprint.md
+++ b/docs/rootprint.md
@@ -1,6 +1,6 @@
 # Rootprint v1
 
-Status: normative for Power House v0.3.2.
+Status: normative for Power House v0.3.3.
 
 Rootprint is the primary Power House provenance workflow. It is a deterministic
 directed acyclic graph whose nodes carry `.pha` artifacts and whose edges record

--- a/docs/rpc_operations.md
+++ b/docs/rpc_operations.md
@@ -1,6 +1,6 @@
 # Power-House RPC Operations
 
-Release scope: Power House v0.3.2.
+Release scope: Power House v0.3.3.
 
 Power-House exposes a native-transfer JSON-RPC lane whose blocks and account
 state are finalized by the configured validator quorum. Chain ID `177155` is

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,6 +1,6 @@
 # SDKs
 
-Power House v0.3.2 ships matching Rust and zero-dependency Python interfaces
+Power House v0.3.3 ships matching Rust and zero-dependency Python interfaces
 for `.pha` and Rootprint v1.
 
 ## Rust

--- a/docs/security_model.md
+++ b/docs/security_model.md
@@ -1,6 +1,6 @@
 # Sparse Certificate Security Model
 
-Status: active security statement for Power House v0.3.2 sparse formats.
+Status: active security statement for Power House v0.3.3 sparse formats.
 
 This document defines what `PHSPv1`, `PHSMv1`, and `PHCPv1` establish and what
 they do not establish.

--- a/docs/sextillion_proof.md
+++ b/docs/sextillion_proof.md
@@ -1,6 +1,6 @@
 # Sextillion-Scale Verification Certificate
 
-Status: active proof profile for Power House v0.3.2.
+Status: active proof profile for Power House v0.3.3.
 
 Power-House can verify a sum-check claim over a domain larger than one
 sextillion points without enumerating the domain.

--- a/docs/sparse_record.md
+++ b/docs/sparse_record.md
@@ -1,6 +1,6 @@
 # Public Sparse Computation Certificate
 
-Status: active format guide for Power House v0.3.2.
+Status: active format guide for Power House v0.3.3.
 
 Power-House now includes an event-driven sum-check prover for a public seeded
 sparse multilinear polynomial:

--- a/docs/testnet_mainnet.md
+++ b/docs/testnet_mainnet.md
@@ -1,6 +1,6 @@
 # MFENX Testnet To Mainnet Process
 
-Release scope: Power House v0.3.2.
+Release scope: Power House v0.3.3.
 
 Chain metadata currently identifies chain `177155` as active. Future mainnet
 launches or incompatible resets must use this process rather than silently

--- a/docs/verification_guide.md
+++ b/docs/verification_guide.md
@@ -1,6 +1,6 @@
 # Verification Guide
 
-This guide reproduces the Power House v0.3.2 provenance and proof workflows.
+This guide reproduces the Power House v0.3.3 provenance and proof workflows.
 
 ## Requirements
 

--- a/publicpower/app.css
+++ b/publicpower/app.css
@@ -1402,6 +1402,15 @@ body.proof-verified .proof-event b {
   background: transparent;
 }
 
+.webgl-fallback .lattice-field {
+  background:
+    rgba(1, 6, 7, 0.58)
+    url("assets/earth-day.jpg")
+    center / cover
+    no-repeat;
+  opacity: 0.58;
+}
+
 .webgl-fallback .target-reticle,
 .webgl-fallback .scene-controls {
   display: none;
@@ -1844,5 +1853,880 @@ body.proof-verified .proof-event b {
     scroll-behavior: auto !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+  }
+}
+
+/* v0.3.3 Observatory command surface */
+:root {
+  --mode-color: #45ddd2;
+  --top: 68px;
+  --dock: 166px;
+  --panel: rgba(3, 9, 10, 0.91);
+  --line: rgba(214, 232, 225, 0.14);
+  --line-strong: rgba(214, 232, 225, 0.32);
+  --acid: #c7ff45;
+  --cyan: #45ddd2;
+  --amber: #ffc15a;
+  --coral: #ff7167;
+}
+
+#app {
+  background: #020607;
+}
+
+.lattice-field {
+  z-index: 0;
+  background: #020607 url("assets/proof-lattice.webp") center / cover no-repeat;
+  opacity: 0.16;
+}
+
+.lattice-field::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: rgba(0, 4, 5, 0.42);
+}
+
+.scan-grid {
+  opacity: 0.11;
+  background-size: 72px 72px;
+}
+
+.edge-vignette {
+  box-shadow:
+    inset 140px 0 180px -130px #010405,
+    inset -140px 0 180px -130px #010405,
+    inset 0 -120px 160px -120px #010405;
+}
+
+.topbar {
+  padding: 0 20px;
+  background: rgba(2, 7, 8, 0.88);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.22);
+}
+
+.brand img {
+  width: 40px;
+  height: 40px;
+  border-color: rgba(69, 221, 210, 0.35);
+  box-shadow: 0 0 22px rgba(69, 221, 210, 0.1);
+}
+
+.brand strong {
+  font-size: 19px;
+}
+
+.brand small {
+  color: #74827d;
+}
+
+.mission-clock {
+  gap: 10px;
+  padding: 8px 12px;
+  border-right: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.018);
+}
+
+.top-actions {
+  gap: 2px;
+}
+
+.top-actions a,
+.top-actions button {
+  min-height: 38px;
+  padding: 0 11px;
+}
+
+.top-actions .evaluation-toggle {
+  min-width: 104px;
+}
+
+.network-ribbon {
+  position: absolute;
+  top: calc(var(--top) + 14px);
+  right: 70px;
+  z-index: 24;
+  display: grid;
+  grid-template-columns: 1.55fr repeat(4, minmax(64px, auto));
+  min-height: 44px;
+  color: #7f8d88;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  border: 1px solid var(--line);
+  background: rgba(2, 8, 9, 0.76);
+  backdrop-filter: blur(14px);
+}
+
+.network-ribbon > div {
+  display: grid;
+  align-content: center;
+  gap: 3px;
+  min-width: 0;
+  padding: 7px 12px;
+  border-right: 1px solid var(--line);
+}
+
+.network-ribbon > div:last-child {
+  border-right: 0;
+}
+
+.network-ribbon span {
+  overflow: hidden;
+  color: #56645f;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.network-ribbon b {
+  overflow: hidden;
+  color: #c2ccc8;
+  font-size: 10px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.network-ribbon-state {
+  grid-template-columns: 8px 1fr;
+}
+
+.network-ribbon-state i {
+  grid-row: span 2;
+  align-self: center;
+  width: 6px;
+  height: 6px;
+  border: 1px solid #82908b;
+  border-radius: 50%;
+}
+
+.network-ribbon-state b {
+  color: var(--amber);
+}
+
+body[data-network="operational"] .network-ribbon-state i {
+  border-color: var(--acid);
+  background: var(--acid);
+  box-shadow: 0 0 12px rgba(199, 255, 69, 0.72);
+}
+
+body[data-network="operational"] .network-ribbon-state b,
+body[data-network="operational"] .network-console-heading b {
+  color: var(--acid);
+}
+
+body[data-network="degraded"] .network-ribbon-state i {
+  border-color: var(--amber);
+  background: var(--amber);
+}
+
+body[data-network="outage"] .network-ribbon-state i {
+  border-color: var(--coral);
+  background: var(--coral);
+}
+
+.proof-rail {
+  top: calc(var(--top) + 20px);
+  left: 20px;
+  width: 252px;
+}
+
+.rail-heading {
+  padding-bottom: 9px;
+}
+
+.rail-heading b {
+  color: #7d8b86;
+  font-size: 8px;
+}
+
+.proof-modes {
+  gap: 4px;
+}
+
+.proof-mode {
+  min-height: 54px;
+  border-color: rgba(214, 232, 225, 0.1);
+  background: rgba(2, 8, 9, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.proof-mode:hover {
+  border-color: rgba(214, 232, 225, 0.3);
+  background: rgba(8, 16, 17, 0.86);
+}
+
+.proof-mode.active {
+  border-color: color-mix(in srgb, var(--mode-color) 58%, transparent);
+  background: rgba(6, 15, 14, 0.94);
+  box-shadow:
+    inset 3px 0 0 var(--mode-color),
+    0 0 26px color-mix(in srgb, var(--mode-color) 8%, transparent);
+}
+
+.proof-mode.active::before {
+  display: none;
+}
+
+.proof-mode.active i {
+  border-color: var(--mode-color);
+  background: var(--mode-color);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--mode-color) 75%, transparent);
+}
+
+.install-command {
+  min-height: 48px;
+  margin-top: 7px;
+  border-color: rgba(69, 221, 210, 0.22);
+  background: rgba(2, 8, 9, 0.78);
+}
+
+.rail-status {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-top: 7px;
+  border: 1px solid var(--line);
+  background: rgba(2, 8, 9, 0.68);
+}
+
+.rail-status div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  padding: 8px 9px;
+}
+
+.rail-status div + div {
+  border-left: 1px solid var(--line);
+}
+
+.rail-status span,
+.rail-status b {
+  overflow: hidden;
+  font-size: 8px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rail-status span {
+  color: #52605b;
+}
+
+.rail-status b {
+  color: #9eaca7;
+}
+
+.center-stage {
+  inset: var(--top) 0 var(--dock);
+}
+
+.stage-label {
+  top: 18px;
+  gap: 1px;
+}
+
+.stage-label strong {
+  font-size: 31px;
+}
+
+.target-reticle {
+  top: 49%;
+  left: 57%;
+  width: 62px;
+  height: 62px;
+  border-color: color-mix(in srgb, var(--mode-color) 34%, transparent);
+  box-shadow: 0 0 36px color-mix(in srgb, var(--mode-color) 8%, transparent);
+}
+
+.target-reticle::before,
+.target-reticle::after {
+  background: color-mix(in srgb, var(--mode-color) 35%, transparent);
+}
+
+.proof-monument {
+  bottom: 22px;
+  left: clamp(298px, 22vw, 390px);
+  width: min(600px, 43vw);
+}
+
+.proof-monument > span {
+  color: var(--mode-color);
+}
+
+.monument-title {
+  display: flex;
+  align-items: flex-end;
+  gap: 15px;
+}
+
+.proof-monument h1 {
+  margin: 5px 0 1px;
+  font-size: 68px;
+}
+
+.monument-title > b {
+  margin-bottom: 7px;
+  padding: 4px 6px;
+  color: var(--mode-color);
+  font-size: 10px;
+  font-weight: 500;
+  border: 1px solid color-mix(in srgb, var(--mode-color) 48%, transparent);
+  background: rgba(2, 8, 9, 0.7);
+}
+
+.proof-monument p {
+  max-width: 530px;
+  color: #a9b6b1;
+}
+
+.domain-equation {
+  border-left-color: color-mix(in srgb, var(--mode-color) 42%, transparent);
+}
+
+.domain-equation strong {
+  color: #f4f8f5;
+  font-size: 48px;
+}
+
+.domain-equation sup {
+  color: var(--mode-color);
+}
+
+.mode-metrics {
+  border-top-color: rgba(214, 232, 225, 0.18);
+}
+
+.mode-metrics b {
+  color: #b8c3bf;
+}
+
+.proof-event {
+  top: auto;
+  right: 76px;
+  bottom: 22px;
+  padding: 8px 10px;
+  border-right: 2px solid var(--mode-color);
+  background: rgba(2, 8, 9, 0.65);
+}
+
+.proof-event b {
+  color: var(--mode-color);
+}
+
+.scene-controls {
+  top: calc(var(--top) + 70px);
+  right: 20px;
+  gap: 5px;
+}
+
+.icon-button {
+  width: 38px;
+  height: 38px;
+  background: rgba(2, 8, 9, 0.82);
+}
+
+.icon-button:hover,
+.icon-button.active {
+  border-color: color-mix(in srgb, var(--mode-color) 55%, transparent);
+  background: rgba(9, 18, 18, 0.94);
+}
+
+.symbol-button b {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.instrument-drawer {
+  width: min(430px, calc(100% - 34px));
+  padding: 20px 18px;
+  background: rgba(2, 8, 9, 0.97);
+  box-shadow: -32px 0 80px rgba(0, 0, 0, 0.34);
+}
+
+.city-search {
+  height: 42px;
+  margin-top: 14px;
+}
+
+.city-row {
+  min-height: 51px;
+  padding: 9px 7px;
+}
+
+.celestial-readout {
+  grid-template-columns: 104px 1fr;
+  grid-template-rows: 38px auto auto;
+  min-height: 172px;
+  padding: 12px 0;
+}
+
+.celestial-primary {
+  grid-row: 1 / 3;
+}
+
+.solar-arc {
+  position: relative;
+  grid-column: 2;
+  height: 30px;
+  margin: 0 0 4px 12px;
+  border-bottom: 1px solid rgba(214, 232, 225, 0.18);
+}
+
+.solar-arc::before,
+.solar-arc::after {
+  position: absolute;
+  bottom: -3px;
+  width: 1px;
+  height: 7px;
+  content: "";
+  background: rgba(214, 232, 225, 0.34);
+}
+
+.solar-arc::before {
+  left: 0;
+}
+
+.solar-arc::after {
+  right: 0;
+}
+
+.solar-arc span {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 20px;
+  border-top: 1px solid rgba(255, 193, 90, 0.24);
+  border-radius: 50% 50% 0 0;
+}
+
+.solar-arc i {
+  position: absolute;
+  bottom: -4px;
+  left: var(--solar-position, 50%);
+  z-index: 2;
+  width: 8px;
+  height: 8px;
+  border: 1px solid #fff1c7;
+  border-radius: 50%;
+  background: var(--amber);
+  box-shadow: 0 0 13px rgba(255, 193, 90, 0.76);
+  transform: translateX(-50%);
+  transition: left 220ms ease;
+}
+
+.celestial-readout dl {
+  grid-column: 2;
+  padding-left: 12px;
+}
+
+.subsolar-line {
+  grid-row: 3;
+}
+
+.time-lab {
+  min-height: 118px;
+}
+
+.network-console {
+  flex: none;
+  margin-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.network-console-heading {
+  display: flex;
+  justify-content: space-between;
+  padding: 11px 0 8px;
+  color: #788681;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+}
+
+.network-console-heading b {
+  color: var(--amber);
+  font-weight: 500;
+}
+
+.network-node-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid var(--line);
+}
+
+.network-node-list button {
+  display: grid;
+  grid-template-columns: 8px 1fr;
+  gap: 6px;
+  min-width: 0;
+  min-height: 64px;
+  padding: 9px 8px;
+  color: #788681;
+  text-align: left;
+  border: 0;
+  border-right: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.018);
+  cursor: pointer;
+}
+
+.network-node-list button:last-child {
+  border-right: 0;
+}
+
+.network-node-list button:hover {
+  color: var(--paper);
+  background: rgba(69, 221, 210, 0.04);
+}
+
+.network-node-list i {
+  align-self: start;
+  width: 5px;
+  height: 5px;
+  margin-top: 3px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+}
+
+.network-node-list button.online i {
+  color: var(--acid);
+  background: var(--acid);
+  box-shadow: 0 0 8px rgba(199, 255, 69, 0.66);
+}
+
+.network-node-list span {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.network-node-list b,
+.network-node-list small,
+.network-node-list strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.network-node-list b {
+  color: #c1ccc7;
+  font-size: 10px;
+}
+
+.network-node-list small,
+.network-node-list strong {
+  grid-column: 2;
+  color: #57645f;
+  font-size: 7px;
+  font-weight: 500;
+}
+
+.network-node-list button.online strong {
+  color: var(--acid);
+}
+
+.network-console > a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 38px;
+  padding: 0 10px;
+  color: #9eaca7;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  border: 1px solid var(--line);
+  border-top: 0;
+}
+
+.network-console > a:hover {
+  color: var(--paper);
+  border-color: rgba(69, 221, 210, 0.4);
+}
+
+.verification-dock {
+  grid-template-columns: minmax(280px, 0.9fr) minmax(360px, 1.5fr) auto;
+  grid-template-rows: 114px 52px;
+  background: rgba(2, 8, 9, 0.96);
+  box-shadow: 0 -28px 70px rgba(0, 0, 0, 0.24);
+}
+
+.trace-header {
+  padding: 14px 20px;
+}
+
+.trace-header > span {
+  color: var(--mode-color);
+}
+
+.trace-header b {
+  font-size: 17px;
+}
+
+.proof-trace i.active {
+  background: var(--mode-color);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--mode-color) 52%, transparent);
+}
+
+.progress-track i {
+  background: var(--mode-color);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--mode-color) 68%, transparent);
+}
+
+.verify-button {
+  color: #081005;
+  border-color: var(--mode-color);
+  background: var(--mode-color);
+}
+
+.verify-button:hover {
+  filter: brightness(1.12);
+}
+
+.status-seal {
+  border-color: color-mix(in srgb, var(--mode-color) 56%, transparent);
+}
+
+.status-seal::after {
+  border-right-color: var(--mode-color);
+  border-left-color: var(--mode-color);
+}
+
+.status-seal b {
+  color: var(--mode-color);
+}
+
+@media (max-width: 1180px) {
+  .network-ribbon {
+    right: 62px;
+    grid-template-columns: 1.4fr repeat(3, minmax(60px, auto));
+  }
+
+  .network-ribbon > div:last-child {
+    display: none;
+  }
+
+  .proof-monument {
+    left: 252px;
+    width: 48vw;
+  }
+
+  .proof-rail {
+    width: 220px;
+  }
+
+  .proof-monument h1 {
+    font-size: 57px;
+  }
+
+  .domain-equation {
+    position: static;
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    min-width: 0;
+    margin-top: 9px;
+    padding: 8px 0 0;
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+
+  .domain-equation strong {
+    font-size: 34px;
+    line-height: 1;
+  }
+
+  .proof-event {
+    display: none;
+  }
+
+  .rail-status {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  :root {
+    --dock: 166px;
+  }
+
+  .network-ribbon {
+    display: none;
+  }
+
+  .proof-rail {
+    top: auto;
+    right: 0;
+    bottom: var(--dock);
+    left: 0;
+    width: auto;
+    padding: 6px 8px;
+  }
+
+  .center-stage {
+    inset: var(--top) 0 calc(var(--dock) + 61px);
+  }
+
+  .proof-mode.active {
+    box-shadow: inset 0 -3px 0 var(--mode-color);
+  }
+
+  .proof-monument {
+    left: 24px;
+    width: 64vw;
+  }
+
+  .proof-event {
+    right: 18px;
+    bottom: 18px;
+  }
+
+  .scene-controls {
+    top: calc(var(--top) + 16px);
+  }
+
+  .verification-dock {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-rows: 114px 52px;
+  }
+}
+
+@media (max-width: 600px) {
+  :root {
+    --top: 58px;
+    --dock: 160px;
+  }
+
+  .lattice-field {
+    opacity: 0.1;
+    background-position: center;
+  }
+
+  .topbar {
+    padding: 0 9px;
+  }
+
+  .brand strong {
+    font-size: 18px;
+  }
+
+  .top-actions .evaluation-toggle {
+    min-width: 34px;
+  }
+
+  .proof-rail {
+    padding: 6px;
+  }
+
+  .center-stage {
+    inset: var(--top) 0 calc(var(--dock) + 60px);
+  }
+
+  .proof-mode {
+    min-height: 48px;
+  }
+
+  .proof-monument {
+    bottom: 12px;
+    left: 13px;
+    width: calc(100% - 26px);
+  }
+
+  .monument-title {
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .proof-monument h1 {
+    max-width: calc(100% - 42px);
+    font-size: 33px;
+    white-space: normal;
+  }
+
+  .monument-title > b {
+    margin-bottom: 4px;
+  }
+
+  .proof-event {
+    display: none;
+  }
+
+  .domain-equation {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 8px;
+    margin-top: 5px;
+    padding-top: 5px;
+  }
+
+  .domain-equation strong {
+    overflow: hidden;
+    font-size: 23px;
+    line-height: 1;
+    text-overflow: ellipsis;
+  }
+
+  .scene-controls {
+    top: calc(var(--top) + 10px);
+    right: auto;
+    left: 8px;
+    grid-template-columns: 32px;
+  }
+
+  .scene-controls .icon-button {
+    width: 32px;
+    height: 32px;
+  }
+
+  #sound-toggle,
+  #motion-toggle,
+  #zoom-out {
+    display: none;
+  }
+
+  .instrument-drawer {
+    width: calc(100% - 14px);
+    padding: 14px;
+  }
+
+  .celestial-readout {
+    grid-template-columns: 94px 1fr;
+  }
+
+  .network-node-list {
+    grid-template-columns: 1fr;
+  }
+
+  .network-node-list button {
+    grid-template-columns: 8px 1fr auto;
+    min-height: 48px;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .network-node-list button:last-child {
+    border-bottom: 0;
+  }
+
+  .network-node-list strong {
+    grid-column: 3;
+    grid-row: 1;
+    align-self: center;
+  }
+
+  .verification-dock {
+    grid-template-columns: minmax(0, 1fr) 102px;
+    grid-template-rows: 108px 52px;
+  }
+
+  .trace-header {
+    padding-left: 62px;
+  }
+
+  .telemetry > div:not(.status-seal) {
+    padding: 0 7px;
   }
 }

--- a/publicpower/app.js
+++ b/publicpower/app.js
@@ -10,6 +10,7 @@ import Crosshair from "./vendor/lucide/crosshair.mjs";
 import Download from "./vendor/lucide/download.mjs";
 import Globe from "./vendor/lucide/globe.mjs";
 import Pause from "./vendor/lucide/pause.mjs";
+import Package from "./vendor/lucide/package.mjs";
 import Play from "./vendor/lucide/play.mjs";
 import RotateCcw from "./vendor/lucide/rotate-ccw.mjs";
 import Search from "./vendor/lucide/search.mjs";
@@ -34,6 +35,7 @@ const iconLibrary = {
   download: Download,
   globe: Globe,
   pause: Pause,
+  package: Package,
   play: Play,
   "rotate-ccw": RotateCcw,
   search: Search,
@@ -177,6 +179,7 @@ const cities = [
   { name: "SAO PAULO", code: "SAO", zone: "America/Sao_Paulo", lat: -23.55, lon: -46.63 },
   { name: "GREENWICH", code: "UTC", zone: "Europe/London", lat: 51.48, lon: 0.0 },
   { name: "PARIS", code: "CDG", zone: "Europe/Paris", lat: 48.86, lon: 2.35 },
+  { name: "AMSTERDAM", code: "AMS", zone: "Europe/Amsterdam", lat: 52.37, lon: 4.9 },
   { name: "LAGOS", code: "LOS", zone: "Africa/Lagos", lat: 6.52, lon: 3.38 },
   { name: "CAIRO", code: "CAI", zone: "Africa/Cairo", lat: 30.04, lon: 31.24 },
   { name: "NAIROBI", code: "NBO", zone: "Africa/Nairobi", lat: -1.29, lon: 36.82 },
@@ -196,6 +199,15 @@ const el = Object.fromEntries(
     "boot-screen",
     "boot-progress",
     "mission-state",
+    "network-indicator",
+    "network-state",
+    "network-block",
+    "network-validators",
+    "network-peers",
+    "network-console-state",
+    "node-sfo-state",
+    "node-nyc-state",
+    "node-ams-state",
     "utc-date",
     "utc-time",
     "city-list",
@@ -211,6 +223,7 @@ const el = Object.fromEntries(
     "moon-phase",
     "moon-light",
     "solar-position",
+    "solar-arc",
     "observatory-mode",
     "time-offset-label",
     "time-slider",
@@ -255,8 +268,14 @@ const el = Object.fromEntries(
     "sound-toggle",
     "motion-toggle",
     "focus-toggle",
+    "network-toggle",
+    "zoom-in",
+    "zoom-out",
+    "view-reset",
     "install-command",
     "globe-tooltip",
+    "monument-index",
+    "network-console",
   ].map((id) => [camelCase(id), document.querySelector(`#${id}`)]),
 );
 el.canvas = el.orbitalCanvas;
@@ -301,10 +320,17 @@ let subsolarMarker;
 let proofShell;
 let proofShellMaterial;
 let proofRingGroup;
+let proofParticles;
+let proofParticlesMaterial;
+let selectedCityHalo;
+let selectedCityBeam;
+let networkGroup;
 let animationFrame;
 let audioContext;
 let latestSolar = null;
 let autoProofTimer = 0;
+const networkLinks = [];
+const networkCityIndexes = [0, 3, 7];
 
 function camelCase(value) {
   return value.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
@@ -531,6 +557,10 @@ function updateAstronomy() {
     altitude > 0 ? "DAYLIGHT" : altitude > -6 ? "CIVIL TWILIGHT" : "NIGHT";
   el.solarState.classList.toggle("night", altitude <= 0);
   el.solarAltitude.textContent = `${altitude >= 0 ? "+" : ""}${altitude.toFixed(1)}°`;
+  el.solarArc.style.setProperty(
+    "--solar-position",
+    `${THREE.MathUtils.clamp((altitude + 90) / 180, 0, 1) * 100}%`,
+  );
   el.sunriseValue.textContent = events.sunrise;
   el.sunsetValue.textContent = events.sunset;
   el.moonPhase.textContent = moonState.name;
@@ -619,6 +649,7 @@ function selectCity(index, focus = true) {
   });
   el.stageCity.textContent = city.name;
   el.stageZone.textContent = city.zone.toUpperCase();
+  updateSelectedCityGeometry();
   if (focus) focusSelectedCity();
   updateAstronomy();
   if (window.innerWidth <= 760) document.body.classList.remove("observatory-open");
@@ -713,6 +744,120 @@ function createEarthGrid() {
   return group;
 }
 
+function elevatedArc(start, end, height = 0.28) {
+  const points = [];
+  for (let index = 0; index <= 72; index += 1) {
+    const progress = index / 72;
+    const point = start
+      .clone()
+      .lerp(end, progress)
+      .normalize()
+      .multiplyScalar(EARTH_RADIUS + 0.035 + Math.sin(progress * Math.PI) * height);
+    points.push(point);
+  }
+  return new THREE.CatmullRomCurve3(points);
+}
+
+function createNetworkTopology() {
+  networkGroup = new THREE.Group();
+  const pairs = [
+    [0, 3],
+    [3, 7],
+    [7, 0],
+  ];
+  pairs.forEach(([fromIndex, toIndex], index) => {
+    const curve = elevatedArc(
+      latLonVector(cities[fromIndex].lat, cities[fromIndex].lon),
+      latLonVector(cities[toIndex].lat, cities[toIndex].lon),
+      0.22 + index * 0.045,
+    );
+    const material = new THREE.LineBasicMaterial({
+      color: index === 1 ? 0xffc15a : 0x45ddd2,
+      transparent: true,
+      opacity: 0.56,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    });
+    const line = new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints(curve.getPoints(96)),
+      material,
+    );
+    const pulse = new THREE.Mesh(
+      new THREE.SphereGeometry(0.025, 12, 8),
+      new THREE.MeshBasicMaterial({
+        color: index === 1 ? 0xffc15a : 0xb9ff3d,
+        transparent: true,
+        opacity: 0.95,
+      }),
+    );
+    networkGroup.add(line, pulse);
+    networkLinks.push({ curve, line, pulse, phase: index / pairs.length });
+  });
+
+  networkCityIndexes.forEach((cityIndex) => {
+    const city = cities[cityIndex];
+    const position = latLonVector(city.lat, city.lon, EARTH_RADIUS + 0.045);
+    const ring = new THREE.Mesh(
+      new THREE.RingGeometry(0.04, 0.057, 28),
+      new THREE.MeshBasicMaterial({
+        color: 0xb9ff3d,
+        transparent: true,
+        opacity: 0.86,
+        side: THREE.DoubleSide,
+        depthWrite: false,
+      }),
+    );
+    ring.position.copy(position);
+    ring.quaternion.setFromUnitVectors(
+      new THREE.Vector3(0, 0, 1),
+      position.clone().normalize(),
+    );
+    networkGroup.add(ring);
+  });
+  earthGroup.add(networkGroup);
+}
+
+function createSelectedCityGeometry() {
+  selectedCityHalo = new THREE.Mesh(
+    new THREE.RingGeometry(0.052, 0.083, 36),
+    new THREE.MeshBasicMaterial({
+      color: 0xb9ff3d,
+      transparent: true,
+      opacity: 0.82,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    }),
+  );
+  selectedCityBeam = new THREE.Line(
+    new THREE.BufferGeometry(),
+    new THREE.LineBasicMaterial({
+      color: 0xb9ff3d,
+      transparent: true,
+      opacity: 0.42,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    }),
+  );
+  earthGroup.add(selectedCityHalo, selectedCityBeam);
+  updateSelectedCityGeometry();
+}
+
+function updateSelectedCityGeometry() {
+  if (!selectedCityHalo || !selectedCityBeam) return;
+  const city = cities[state.activeCity];
+  const surface = latLonVector(city.lat, city.lon, EARTH_RADIUS + 0.045);
+  selectedCityHalo.position.copy(surface);
+  selectedCityHalo.quaternion.setFromUnitVectors(
+    new THREE.Vector3(0, 0, 1),
+    surface.clone().normalize(),
+  );
+  selectedCityBeam.geometry.dispose();
+  selectedCityBeam.geometry = new THREE.BufferGeometry().setFromPoints([
+    surface,
+    surface.clone().normalize().multiplyScalar(EARTH_RADIUS + 0.46),
+  ]);
+}
+
 async function createEarth() {
   const mobile = window.innerWidth <= 760;
   const [dayTexture, nightTexture] = await Promise.all([
@@ -750,14 +895,17 @@ async function createEarth() {
       varying vec3 vViewPosition;
       void main() {
         float solar = dot(normalize(vObjectNormal), normalize(sunDirection));
-        float daylight = smoothstep(-0.13, 0.18, solar);
+        float daylight = smoothstep(-0.22, 0.16, solar);
         vec3 day = texture2D(dayMap, vUv).rgb;
-        vec3 night = texture2D(nightMap, vUv).rgb * 1.32;
-        vec3 litDay = day * (0.48 + max(solar, 0.0) * 0.70);
+        vec3 night = texture2D(nightMap, vUv).rgb * 2.05;
+        vec3 litDay = day * (0.68 + max(solar, 0.0) * 0.72);
         vec3 viewDirection = normalize(-vViewPosition);
         float limb = pow(1.0 - max(dot(normalize(vViewNormal), viewDirection), 0.0), 3.0);
+        float terminator = 1.0 - smoothstep(0.0, 0.18, abs(solar));
         vec3 color = mix(night, litDay, daylight);
-        color += vec3(0.035, 0.24, 0.22) * limb * 0.52;
+        color += day * 0.08;
+        color += vec3(0.05, 0.34, 0.3) * limb * 0.78;
+        color += vec3(0.11, 0.42, 0.36) * terminator * 0.11;
         gl_FragColor = vec4(color, 1.0);
       }
     `,
@@ -822,6 +970,9 @@ async function createEarth() {
     interactiveObjects.push(hitMarker);
     earthGroup.add(marker, hitMarker);
   });
+
+  createNetworkTopology();
+  createSelectedCityGeometry();
 
   const solarGroup = new THREE.Group();
   const solarRing = new THREE.Mesh(
@@ -922,7 +1073,32 @@ function createProofField() {
     ring.rotation.set(0.38 + index * 0.48, index * 0.36, -0.24 + index * 0.42);
     proofRingGroup.add(ring);
   });
-  scene.add(proofShell, proofRingGroup);
+
+  const pointCount = window.innerWidth <= 760 ? 900 : 2400;
+  const positions = new Float32Array(pointCount * 3);
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+  for (let index = 0; index < pointCount; index += 1) {
+    const y = 1 - (index / (pointCount - 1)) * 2;
+    const radial = Math.sqrt(1 - y * y);
+    const angle = goldenAngle * index;
+    const shell = 1.58 + ((index * 17) % 23) * 0.006;
+    positions[index * 3] = Math.cos(angle) * radial * shell;
+    positions[index * 3 + 1] = y * shell;
+    positions[index * 3 + 2] = Math.sin(angle) * radial * shell;
+  }
+  const particleGeometry = new THREE.BufferGeometry();
+  particleGeometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  proofParticlesMaterial = new THREE.PointsMaterial({
+    color: modes[state.mode].color,
+    size: window.innerWidth <= 760 ? 0.012 : 0.009,
+    transparent: true,
+    opacity: 0.2,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+    sizeAttenuation: true,
+  });
+  proofParticles = new THREE.Points(particleGeometry, proofParticlesMaterial);
+  scene.add(proofShell, proofRingGroup, proofParticles);
 }
 
 function createMoon() {
@@ -962,7 +1138,7 @@ async function initScene() {
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 1.13;
+  renderer.toneMappingExposure = 1.28;
   renderer.setClearColor(0x010405, 0.42);
 
   scene = new THREE.Scene();
@@ -1130,6 +1306,18 @@ function animate(time = 0) {
       beacon.scale.setScalar(pulse + progressBoost);
     });
   }
+  if (networkGroup) {
+    networkLinks.forEach(({ curve, pulse, line, phase }, index) => {
+      const progress = (phase + seconds * (0.055 + index * 0.008)) % 1;
+      pulse.position.copy(curve.getPoint(progress));
+      pulse.scale.setScalar(0.85 + Math.sin(seconds * 7 + index) * 0.24);
+      line.material.opacity = 0.38 + Math.sin(seconds * 1.4 + index) * 0.13;
+    });
+  }
+  if (selectedCityHalo) {
+    selectedCityHalo.scale.setScalar(1 + Math.sin(seconds * 4.5) * 0.18);
+    selectedCityHalo.material.opacity = 0.66 + Math.sin(seconds * 4.5) * 0.16;
+  }
   if (subsolarMarker) {
     subsolarMarker.scale.setScalar(1 + Math.sin(seconds * 3) * 0.12);
   }
@@ -1146,6 +1334,14 @@ function animate(time = 0) {
       ring.rotation.y += state.motion ? 0.0008 * (index + 1) : 0;
       ring.rotation.z += state.motion ? 0.00045 * (index % 2 ? -1 : 1) : 0;
     });
+  }
+  if (proofParticles) {
+    proofParticles.rotation.y = seconds * -0.018;
+    proofParticles.rotation.z = seconds * 0.006;
+    proofParticlesMaterial.color.setHex(modes[state.mode].color);
+    proofParticlesMaterial.opacity =
+      0.12 + state.proofProgress * 0.52 + (state.running ? 0.08 : 0);
+    proofParticles.scale.setScalar(1 + state.proofProgress * 0.12);
   }
   if (moon) moon.rotation.y += state.motion ? 0.0015 : 0;
   camera.position.z += (state.zoom - camera.position.z) * 0.06;
@@ -1206,6 +1402,10 @@ function selectMode(name, withTone = true) {
   state.mode = name;
   state.lastResult = null;
   const mode = modes[name];
+  document.documentElement.style.setProperty(
+    "--mode-color",
+    `#${mode.color.toString(16).padStart(6, "0")}`,
+  );
   document.querySelectorAll(".proof-mode").forEach((button) => {
     const active = button.dataset.mode === name;
     button.classList.toggle("active", active);
@@ -1235,6 +1435,7 @@ function selectMode(name, withTone = true) {
     mode.dossierDomain ?? `2^${mode.exponent.toLocaleString()}`;
   el.dossierWork.textContent = mode.verifierPath;
   el.dossierArtifact.textContent = mode.dossierArtifact;
+  el.monumentIndex.textContent = String(Object.keys(modes).indexOf(name) + 1).padStart(2, "0");
   el.downloadButton.href = mode.downloadHref;
   el.downloadButton.target = mode.downloadName ? "" : "_blank";
   if (mode.downloadName) el.downloadButton.setAttribute("download", mode.downloadName);
@@ -1790,6 +1991,40 @@ function showToast(message) {
   state.toastTimer = window.setTimeout(() => el.toast.classList.remove("show"), 3600);
 }
 
+function updateNetworkNodeStates(healthy) {
+  const nodeFields = [el.nodeSfoState, el.nodeNycState, el.nodeAmsState];
+  nodeFields.forEach((field, index) => {
+    const online = index < healthy;
+    field.textContent = online ? "ONLINE" : "CHECK";
+    field.closest("button").classList.toggle("online", online);
+  });
+}
+
+async function refreshNetworkStatus() {
+  try {
+    const response = await fetch("https://rpc.mfenx.com/network-status.json", {
+      cache: "no-store",
+    });
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+
+    const networkState = data.status || "degraded";
+    const healthy = Number(data.validators_healthy) || 0;
+    document.body.dataset.network = networkState;
+    el.networkState.textContent = networkState.toUpperCase();
+    el.networkConsoleState.textContent = networkState.toUpperCase();
+    el.networkBlock.textContent = Number(data.block_height).toLocaleString("en-US");
+    el.networkValidators.textContent = `${healthy} / ${Number(data.validators_total) || 3}`;
+    el.networkPeers.textContent = Number(data.peer_connections).toLocaleString("en-US");
+    updateNetworkNodeStates(healthy);
+  } catch {
+    document.body.dataset.network = "unknown";
+    el.networkState.textContent = "FEED CHECK";
+    el.networkConsoleState.textContent = "FEED CHECK";
+    updateNetworkNodeStates(0);
+  }
+}
+
 async function copyText(value, successMessage) {
   try {
     await navigator.clipboard.writeText(value);
@@ -1889,6 +2124,29 @@ function bindInterface() {
     focusSelectedCity();
     showToast(`${cities[state.activeCity].name} centered`);
   });
+  el.networkToggle.addEventListener("click", () => {
+    document.body.classList.remove("evaluation-open");
+    document.body.classList.add("observatory-open");
+    window.setTimeout(
+      () => el.networkConsole.scrollIntoView({ behavior: "smooth", block: "end" }),
+      300,
+    );
+  });
+  el.zoomIn.addEventListener("click", () => {
+    state.zoom = Math.max(3.45, state.zoom - 0.32);
+  });
+  el.zoomOut.addEventListener("click", () => {
+    state.zoom = Math.min(6.2, state.zoom + 0.32);
+  });
+  el.viewReset.addEventListener("click", () => {
+    setTimeOffset(0);
+    focusSelectedCity();
+    state.zoom = window.innerWidth < 760 ? 4.85 : 4.55;
+    showToast("Orbital view reset");
+  });
+  document.querySelectorAll("[data-network-city]").forEach((button) => {
+    button.addEventListener("click", () => selectCity(Number(button.dataset.networkCity)));
+  });
   el.soundToggle.addEventListener("click", () => setSound(!state.sound));
   el.motionToggle.addEventListener("click", () => setMotion(!state.motion));
   window.addEventListener("resize", resize);
@@ -1926,17 +2184,45 @@ function bindInterface() {
   });
 }
 
+function applyUrlState() {
+  const params = new URLSearchParams(window.location.search);
+  const requestedMode = params.get("mode");
+  if (requestedMode && modes[requestedMode]) state.mode = requestedMode;
+
+  const requestedCity = params.get("city")?.toUpperCase();
+  if (requestedCity) {
+    const cityIndex = cities.findIndex(
+      (city) => city.code === requestedCity || city.name === requestedCity,
+    );
+    if (cityIndex >= 0) state.activeCity = cityIndex;
+  }
+
+  const requestedOffset = Number(params.get("time"));
+  if (Number.isFinite(requestedOffset)) {
+    state.timeOffsetHours = THREE.MathUtils.clamp(requestedOffset, -24, 24);
+  }
+
+  const panel = params.get("panel");
+  if (panel === "observatory") document.body.classList.add("observatory-open");
+  if (panel === "evaluation") document.body.classList.add("evaluation-open");
+}
+
 function init() {
   mountIcons();
   setBootProgress(22);
   buildProofTrace();
   buildCityList();
   bindInterface();
-  selectMode("rootprint", false);
+  applyUrlState();
+  selectMode(state.mode, false);
   selectCity(state.activeCity, false);
+  focusSelectedCity();
+  setTimeOffset(state.timeOffsetHours);
   setMotion(state.motion);
   updateAstronomy();
+  refreshNetworkStatus();
   window.setInterval(updateAstronomy, 1000);
+  window.setInterval(refreshNetworkStatus, 15_000);
   initScene();
 }
 

--- a/publicpower/index.html
+++ b/publicpower/index.html
@@ -71,10 +71,22 @@
       </nav>
     </header>
 
+    <section class="network-ribbon" aria-label="Live MFENX network telemetry">
+      <div class="network-ribbon-state">
+        <i id="network-indicator"></i>
+        <span>LAX MFENX RPC</span>
+        <b id="network-state">SYNCING</b>
+      </div>
+      <div><span>CHAIN</span><b>177155</b></div>
+      <div><span>BLOCK</span><b id="network-block">--</b></div>
+      <div><span>VALIDATORS</span><b id="network-validators">-- / 3</b></div>
+      <div><span>PEERS</span><b id="network-peers">--</b></div>
+    </section>
+
     <aside class="proof-rail" aria-label="Proof modes">
       <div class="rail-heading">
-        <span>PUBLIC PROOF ARRAY</span>
-        <b>05</b>
+        <span>VERIFICATION ARRAY</span>
+        <b>05 PUBLIC PATHS</b>
       </div>
 
       <div id="proof-modes" class="proof-modes">
@@ -109,6 +121,11 @@
         <span><small>RUST</small><code>cargo add power_house</code></span>
         <span data-icon="copy"></span>
       </button>
+
+      <div class="rail-status" aria-label="Release state">
+        <div><span>RELEASE</span><b>v0.3.3</b></div>
+        <div><span>CORE</span><b>DETERMINISTIC</b></div>
+      </div>
     </aside>
 
     <main class="center-stage">
@@ -123,7 +140,10 @@
 
       <section class="proof-monument" aria-label="Selected proof scale">
         <span id="orbit-kicker">DETERMINISTIC PROVENANCE GRAPH</span>
-        <h1>POWER HOUSE</h1>
+        <div class="monument-title">
+          <h1>POWER HOUSE</h1>
+          <b id="monument-index">01</b>
+        </div>
         <div class="domain-equation">
           <small id="domain-caption">PUBLIC STRUCTURE</small>
           <strong id="domain-label">DAG<sup>4</sup></strong>
@@ -145,6 +165,18 @@
     <div class="scene-controls" aria-label="Scene controls">
       <button id="focus-toggle" class="icon-button" type="button" aria-label="Focus selected city" title="Focus selected city">
         <span data-icon="crosshair"></span>
+      </button>
+      <button id="network-toggle" class="icon-button" type="button" aria-label="Open network topology" title="Network topology">
+        <span data-icon="package"></span>
+      </button>
+      <button id="zoom-in" class="icon-button symbol-button" type="button" aria-label="Zoom in" title="Zoom in">
+        <b>+</b>
+      </button>
+      <button id="zoom-out" class="icon-button symbol-button" type="button" aria-label="Zoom out" title="Zoom out">
+        <b>-</b>
+      </button>
+      <button id="view-reset" class="icon-button" type="button" aria-label="Reset orbital view" title="Reset orbital view">
+        <span data-icon="rotate-ccw"></span>
       </button>
       <button id="sound-toggle" class="icon-button" type="button" aria-label="Enable interface sound" title="Toggle interface sound">
         <span data-icon="volume-x"></span>
@@ -174,6 +206,10 @@
           <span id="solar-state">DAYLIGHT</span>
           <b id="solar-altitude">+00.0°</b>
           <small>SOLAR ALTITUDE</small>
+        </div>
+        <div id="solar-arc" class="solar-arc" aria-hidden="true">
+          <i></i>
+          <span></span>
         </div>
         <dl>
           <div><dt>SUNRISE</dt><dd id="sunrise-value">--:--</dd></div>
@@ -206,6 +242,28 @@
         <input id="time-slider" type="range" min="-24" max="24" step="1" value="0" aria-label="Time offset from live, in hours">
         <div class="time-scale" aria-hidden="true"><span>-24H</span><span>NOW</span><span>+24H</span></div>
       </section>
+
+      <section id="network-console" class="network-console" aria-label="Validator topology">
+        <div class="network-console-heading">
+          <span>REGIONAL QUORUM</span>
+          <b id="network-console-state">SYNCING</b>
+        </div>
+        <div class="network-node-list">
+          <button type="button" data-network-city="0">
+            <i></i><span><b>SFO3</b><small>SAN FRANCISCO</small></span><strong id="node-sfo-state">CHECK</strong>
+          </button>
+          <button type="button" data-network-city="3">
+            <i></i><span><b>NYC3</b><small>NEW YORK</small></span><strong id="node-nyc-state">CHECK</strong>
+          </button>
+          <button type="button" data-network-city="7">
+            <i></i><span><b>AMS3</b><small>AMSTERDAM</small></span><strong id="node-ams-state">CHECK</strong>
+          </button>
+        </div>
+        <a href="status.html">
+          <span>OPEN NETWORK CONTROL</span>
+          <span data-icon="chevron-right"></span>
+        </a>
+      </section>
     </aside>
 
     <aside id="evaluation-panel" class="instrument-drawer evaluation-drawer" aria-label="Technical evaluation">
@@ -236,7 +294,7 @@
       <div class="evaluation-links">
         <a href="https://github.com/JROChub/power_house/blob/main/docs/verification_guide.md">REPRODUCE</a>
         <a href="https://github.com/JROChub/power_house/blob/main/docs/security_model.md">SECURITY MODEL</a>
-        <a href="https://crates.io/crates/power_house">CRATE v0.3.2</a>
+        <a href="https://crates.io/crates/power_house">CRATE v0.3.3</a>
       </div>
     </aside>
 
@@ -277,7 +335,7 @@
         <div><span>CLAIM</span><b id="claim-value">WAITING</b></div>
         <div><span>DIGEST</span><b id="digest-value">PENDING</b></div>
         <div><span>MODE</span><b id="mode-value">ROOTPRINT</b></div>
-        <div><span>RELEASE</span><b>v0.3.2</b></div>
+        <div><span>RELEASE</span><b>v0.3.3</b></div>
       </div>
     </section>
 

--- a/publicpower/status.html
+++ b/publicpower/status.html
@@ -17,7 +17,7 @@
       <img src="assets/powerhouse-logo.png" alt="">
       <span><b>MFENX</b><small>POWER HOUSE NETWORK CONTROL</small></span>
     </a>
-    <div class="release"><span>RELEASE</span><b>v0.3.2</b></div>
+    <div class="release"><span>RELEASE</span><b>v0.3.3</b></div>
   </header>
 
   <main>

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -108,9 +108,38 @@ def main() -> int:
     )
 
     network = json.loads(read("configs/network.json"))
-    benchmark = json.loads(read(f"benchmarks/v{version}/rpc-report.json"))
+    benchmark_path = network.get("benchmarkReport")
+    benchmark_match = (
+        re.fullmatch(
+            r"benchmarks/v(\d+\.\d+\.\d+)/rpc-report\.json", benchmark_path
+        )
+        if isinstance(benchmark_path, str)
+        else None
+    )
+    require(errors, benchmark_match is not None, "network benchmark report path is invalid")
+    benchmark = (
+        json.loads(read(benchmark_path))
+        if isinstance(benchmark_path, str) and (ROOT / benchmark_path).is_file()
+        else {}
+    )
     require(errors, network.get("release") == version, "network metadata version differs")
-    require(errors, benchmark.get("release") == version, "RPC benchmark version differs")
+    require(
+        errors,
+        benchmark.get("schema") == "power-house-rpc-acceptance-v1",
+        "RPC benchmark schema differs",
+    )
+    require(
+        errors,
+        benchmark_match is not None
+        and benchmark.get("release") == benchmark_match.group(1),
+        "RPC benchmark release does not match its versioned path",
+    )
+    require(
+        errors,
+        benchmark.get("environment", {}).get("endpoint")
+        == network.get("rpc", {}).get("canonicalUrl"),
+        "RPC benchmark endpoint differs",
+    )
     require(errors, network.get("chainId") == 177155, "network chain ID differs")
     require(
         errors,

--- a/scripts/check_rustdoc_links.py
+++ b/scripts/check_rustdoc_links.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Verify that README API links resolve in the generated rustdoc tree."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_RS_PREFIX = "https://docs.rs/power_house/latest/power_house/"
+EXPECTED_API_PAGES = (
+    "provenance/pha/struct.PhaArtifact.html",
+    "provenance/rootprint/struct.Rootprint.html",
+    "macro.prove_with_rootprint.html",
+    "sumcheck/struct.GeneralSumProof.html",
+    "sparse_sumcheck/struct.SeededSparseProof.html",
+    "sparse_sumcheck/struct.CommittedSparsePolynomial.html",
+    "sparse_sumcheck/struct.CommittedSparseProof.html",
+    "julian/struct.ProofLedger.html",
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--doc-root",
+        type=Path,
+        default=ROOT / "target" / "doc" / "power_house",
+        help="generated power_house rustdoc directory",
+    )
+    args = parser.parse_args()
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    for page in EXPECTED_API_PAGES:
+        url = f"{DOCS_RS_PREFIX}{page}"
+        if url not in readme:
+            errors.append(f"README is missing the canonical API link: {url}")
+
+        generated = args.doc_root / page
+        if not generated.is_file() or generated.stat().st_size == 0:
+            errors.append(f"generated rustdoc page is missing or empty: {generated}")
+
+    if errors:
+        for error in errors:
+            print(f"RUSTDOC LINK FAIL: {error}", file=sys.stderr)
+        return 1
+
+    print(f"RUSTDOC LINK PASS: {len(EXPECTED_API_PAGES)} README API pages")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_observatory_contract.py
+++ b/scripts/test_observatory_contract.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate Observatory controls and immutable public proof artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+from html.parser import HTMLParser
+import json
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLIC = ROOT / "publicpower"
+ARTIFACTS = {
+    "artifacts/rootprint-valid.json": (
+        4_232,
+        "eeb33450c6473c082675b8fcdaf70abfb0e6070fe739eeda5c839070d13750a3",
+    ),
+    "artifacts/power_house_sparse_record.phsp": (
+        16_000_171,
+        "2b219ba189c3a38f1073c7797629e9aaf44a36820abb64c7628129480eb43f3b",
+    ),
+    "artifacts/external_interaction_model.phsm": (
+        591_464,
+        "c8376831f47a50a7423be6412776382bc23618b037e9fdd163594d389d68864d",
+    ),
+    "artifacts/external_interaction_model.phcp": (
+        16_000_128,
+        "82045e6eb851991e08d9c4cd782abff3bb06cb8ec5f149e7c2d4287113e6a54a",
+    ),
+}
+
+
+class IdParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: list[str] = []
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del tag
+        for name, value in attrs:
+            if name == "id" and value:
+                self.ids.append(value)
+
+
+def fail(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def main() -> int:
+    errors: list[str] = []
+    html = (PUBLIC / "index.html").read_text(encoding="utf-8")
+    javascript = (PUBLIC / "app.js").read_text(encoding="utf-8")
+
+    parser = IdParser()
+    parser.feed(html)
+    duplicates = sorted({value for value in parser.ids if parser.ids.count(value) > 1})
+    if duplicates:
+        fail(errors, f"duplicate HTML IDs: {', '.join(duplicates)}")
+
+    element_block = re.search(
+        r"const el = Object\.fromEntries\(\s*\[(.*?)\]\.map",
+        javascript,
+        re.DOTALL,
+    )
+    if element_block is None:
+        fail(errors, "could not locate the Observatory element registry")
+    else:
+        registered = re.findall(r'"([a-z0-9-]+)"', element_block.group(1))
+        missing = sorted(set(registered) - set(parser.ids))
+        if missing:
+            fail(errors, f"registered controls missing from HTML: {', '.join(missing)}")
+
+    for relative, (expected_size, expected_hash) in ARTIFACTS.items():
+        path = PUBLIC / relative
+        if not path.is_file():
+            fail(errors, f"missing public artifact: {relative}")
+            continue
+        payload = path.read_bytes()
+        if len(payload) != expected_size:
+            fail(
+                errors,
+                f"{relative} size differs: expected {expected_size}, received {len(payload)}",
+            )
+        digest = hashlib.sha256(payload).hexdigest()
+        if digest != expected_hash:
+            fail(errors, f"{relative} SHA-256 differs")
+
+    rootprint = json.loads((PUBLIC / "artifacts/rootprint-valid.json").read_text())
+    if rootprint.get("schema") != "power-house/rootprint/v1":
+        fail(errors, "public Rootprint schema differs")
+
+    required_visual_contracts = (
+        "createNetworkTopology",
+        "createSelectedCityGeometry",
+        "proofParticlesMaterial",
+        "refreshNetworkStatus",
+        "verifyReleaseArtifacts",
+    )
+    for contract in required_visual_contracts:
+        if contract not in javascript:
+            fail(errors, f"missing Observatory behavior: {contract}")
+
+    if errors:
+        for error in errors:
+            print(f"OBSERVATORY CONTRACT FAIL: {error}", file=sys.stderr)
+        return 1
+    print(
+        f"OBSERVATORY CONTRACT PASS: {len(parser.ids)} controls, "
+        f"{len(ARTIFACTS)} immutable artifacts"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,6 @@
 # Power House Python SDK
 
-Version: 0.3.2
+Version: 0.3.3
 
 The default `power_house` namespace implements `.pha` v1 and Rootprint v1
 without requiring or interpreting external proof attachments.

--- a/sdk/python/power_house/__init__.py
+++ b/sdk/python/power_house/__init__.py
@@ -34,4 +34,4 @@ __all__ = [
     "verify_rootprint",
 ]
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "power-house-sdk"
-version = "0.3.2"
+version = "0.3.3"
 description = "Zero-dependency Python SDK for Power House Archive and Rootprint v1"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- repair all Primary Rust API docs.rs links and add generated-rustdoc validation
- rebuild the Orbital Observatory with live network telemetry, validator geometry, proof-reactive rendering, and stronger controls
- synchronize v0.3.3 across Rust, Python, containers, website, network metadata, and active documentation
- add immutable browser artifact and control-binding contract tests

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
- cargo test --all-targets --locked
- cargo test --all-targets --features net --locked
- cargo package --locked
- CLI, RPC, native replica, Python SDK, sparse mutation, Observatory, and live RPC gates
- GPU screenshots and canvas pixel checks at desktop, tablet, mobile, and open-drawer viewports