### PR TITLE
Release v0.3.4 signed validator registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,12 @@ jobs:
             scripts/check_rustdoc_links.py \
             scripts/rpc_load_test.py \
             scripts/test_observatory_contract.py \
+            scripts/test_status_registry.py \
+            scripts/test_validator_registry.py \
             infra/ops/healthcheck.py \
             infra/monitoring/alert_receiver.py \
-            infra/monitoring/status_api.py
+            infra/monitoring/status_api.py \
+            infra/monitoring/validator_registry.py
           jq empty configs/network.json contrib/grafana/mfenx_powerhouse_dashboard.json
           terraform -chdir=infra/terraform/digitalocean fmt -check
           terraform -chdir=infra/terraform/digitalocean init -backend=false
@@ -71,6 +74,11 @@ jobs:
 
       - name: RPC cluster bundle tests
         run: python3 scripts/test_generate_rpc_cluster.py
+
+      - name: Signed validator registry
+        run: |
+          python3 scripts/test_validator_registry.py
+          python3 scripts/test_status_registry.py
 
       - name: DigitalOcean provisioning contract
         run: scripts/test_digitalocean_provision.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "power_house"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "power_house"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["MFENX LLC"]
 description = "Deterministic proofs, portable .pha provenance, Rootprint graphs, and optional quorum networking."
@@ -30,6 +30,7 @@ include = [
   "infra/monitoring/*.conf",
   "infra/monitoring/*.py",
   "infra/monitoring/*.service",
+  "infra/monitoring/*.timer",
   "infra/monitoring/*.yml",
   "infra/scripts/*.sh",
   "infra/systemd/*",
@@ -54,6 +55,8 @@ include = [
   "scripts/test_native_rpc_cluster.sh",
   "scripts/test_observatory_contract.py",
   "scripts/test_rpc_check.py",
+  "scripts/test_status_registry.py",
+  "scripts/test_validator_registry.py",
   "scripts/test_sparse_verifier.py",
   "scripts/verify_sparse_certificate.py",
   "sdk/python/**",

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN cargo build --release --locked --features net --bin julian
 
 FROM debian:bookworm-slim
-ARG POWER_HOUSE_VERSION=0.3.3
+ARG POWER_HOUSE_VERSION=0.3.4
 LABEL org.opencontainers.image.title="Power House" \
   org.opencontainers.image.version="${POWER_HOUSE_VERSION}" \
   org.opencontainers.image.source="https://github.com/JROChub/power_house"

--- a/JULIAN_PROTOCOL.md
+++ b/JULIAN_PROTOCOL.md
@@ -1,5 +1,5 @@
 MFENX Power-House Network: The JULIAN Protocol Network
-Version 0.3.3 - June 2026
+Version 0.3.4 - June 2026
 
 
 # JULIAN Protocol: Proof-Transparent Consensus via Folding-Derived Anchors

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ combines structured sum-check proofs, portable `.pha` artifacts, Rootprint
 proof-history graphs, commitment-bound sparse workloads, transcript anchoring,
 and an optional quorum network.
 
-Current release: **v0.3.3**
+Current release: **v0.3.4**
 
 The primary workflow is **Power House + Rootprint**:
 
@@ -133,6 +133,8 @@ The complete procedure and expected rejection behavior are documented in the
   external workload binding.
 - [`ProofLedger`](https://docs.rs/power_house/latest/power_house/julian/struct.ProofLedger.html):
   transcript logs, anchors, and quorum reconciliation.
+- [`ValidatorRegistry`](https://docs.rs/power_house/latest/power_house/net/validator_registry/struct.ValidatorRegistry.html):
+  signed identity admission and monitoring discovery records.
 
 ## Python SDK
 
@@ -175,7 +177,9 @@ and a quorum-finalized native JSON-RPC lane.
 
 The production edge uses health-aware global routing across validators in
 New York, San Francisco, and Amsterdam. Public traffic is rate-limited at
-Nginx and removed from a backend automatically when `/healthz` fails.
+Nginx and removed from a backend automatically when `/healthz` fails. Signed
+validator registrations bind each admitted public key to its derived peer ID
+and live identity metrics; validator totals are not inferred from peer links.
 
 ```bash
 julian net start \
@@ -207,6 +211,7 @@ Start with the [Documentation Index](docs/README.md).
 - [RPC Operations](docs/rpc_operations.md)
 - [Production RPC Deployment](docs/production_rpc_deployment.md)
 - [Stable Public Network Roadmap](docs/network_roadmap.md)
+- [Signed Validator Registry](docs/validator_registry.md)
 - [Node Operator Guide](docs/node_operator.md)
 - [Incident Response](docs/incident_response.md)
 - [Load Testing](docs/load_testing.md)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,36 @@
 # Release Notes
 
+## v0.3.4 - 2026-06-13
+
+### Signed Validator Registry
+- Added versioned validator registrations signed by each node's existing
+  Ed25519 identity.
+- Bound every registration to its derived libp2p peer ID, chain ID, p2p
+  address, operator, region, monitoring endpoints, and validity window.
+- Required explicit admission by the active validator policy before a record
+  can affect public validator totals.
+- Added `julian validator-registry create`, `assemble`, and `verify`.
+
+### Live Identity And Health
+- Added `powerhouse_node_identity` metrics so the registry reconciler can
+  compare the live node ID, peer ID, public key, and chain ID with the signed
+  registration.
+- Replaced hardcoded Prometheus validator targets with atomic file discovery.
+- Added concurrent validator and system health probes, bounded responses,
+  redirect rejection, stale-state detection, and last-known-good discovery
+  preservation when registry verification fails.
+- Updated the public status API and website to report dynamic registered and
+  healthy validator totals independently from peer-link observations.
+
+### Safety And Testing
+- Kept monitoring enrollment separate from persisted consensus membership and
+  quorum transitions.
+- Added signature mutation, identity mismatch, expiration, duplicate,
+  unadmitted-key, stale-state, dynamic-count, deployment-bundle, and
+  reconciliation tests.
+- Retained the existing three-validator finalized network while making
+  monitoring discovery ready for controlled future validator admission.
+
 ## v0.3.3 - 2026-06-13
 
 ### Documentation

--- a/configs/network.json
+++ b/configs/network.json
@@ -7,7 +7,7 @@
     "name": "JULIAN",
     "symbol": "JULIAN"
   },
-  "release": "0.3.3",
+  "release": "0.3.4",
   "benchmarkReport": "benchmarks/v0.3.2/rpc-report.json",
   "rpc": {
     "canonicalUrl": "https://rpc.mfenx.com",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   node:
-    image: ghcr.io/jrochub/power_house:0.3.3
+    image: ghcr.io/jrochub/power_house:0.3.4
     build: .
     command:
       [

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Power House Documentation
 
-This index is the authoritative map for Power House v0.3.3 documentation.
+This index is the authoritative map for Power House v0.3.4 documentation.
 
 ## Start Here
 
@@ -14,6 +14,7 @@ This index is the authoritative map for Power House v0.3.3 documentation.
 | [SDKs](sdk.md) | Rust and Python interfaces and cross-language interoperability |
 | [JULIAN Protocol](../JULIAN_PROTOCOL.md) | Transcript anchoring, quorum reconciliation, and network architecture |
 | [Stable Public Network Roadmap](network_roadmap.md) | Production topology, completion evidence, and remaining decentralization work |
+| [Signed Validator Registry](validator_registry.md) | Identity-bound validator enrollment, health reconciliation, and dynamic monitoring discovery |
 
 ## Proof Systems And Formats
 

--- a/docs/committed_workload.md
+++ b/docs/committed_workload.md
@@ -1,6 +1,6 @@
 # Externally Committed Sparse Workload
 
-Status: active format guide for Power House v0.3.3.
+Status: active format guide for Power House v0.3.4.
 
 Power-House can now bind a sum-check certificate to a separately supplied
 sparse polynomial file.

--- a/docs/hyperscale_proof.md
+++ b/docs/hyperscale_proof.md
@@ -1,6 +1,6 @@
 # Hyperscale Seeded-Affine Proof
 
-Status: active proof profile for Power House v0.3.3.
+Status: active proof profile for Power House v0.3.4.
 
 `examples/hyperscale_affine.rs` demonstrates a non-constant sum-check
 certificate over domains far larger than sextillion scale.

--- a/docs/incident_response.md
+++ b/docs/incident_response.md
@@ -1,6 +1,6 @@
 # MFENX Incident Response
 
-Release scope: Power House v0.3.3.
+Release scope: Power House v0.3.4.
 
 ## Severity
 

--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -1,6 +1,6 @@
 # MFENX Network Load Testing
 
-Release scope: Power House v0.3.3.
+Release scope: Power House v0.3.4.
 
 Run read-only public RPC tests before transaction tests. Never direct an
 unbounded load generator at production.

--- a/docs/network_roadmap.md
+++ b/docs/network_roadmap.md
@@ -1,6 +1,6 @@
 # MFENX Stable Public Network Roadmap
 
-Release scope: Power House v0.3.3.
+Release scope: Power House v0.3.4.
 
 The target is a public network that fails predictably, recovers automatically,
 and exposes enough evidence for operators and users to determine its state.

--- a/docs/node_operator.md
+++ b/docs/node_operator.md
@@ -1,6 +1,6 @@
 # MFENX Node Operator Guide
 
-Release scope: Power House v0.3.3.
+Release scope: Power House v0.3.4.
 
 This guide starts a public observer. Validator admission additionally requires
 a consensus identity approved by the active membership policy.
@@ -19,14 +19,14 @@ unless a firewall and authenticated reverse proxy explicitly protect them.
 ## Install
 
 ```bash
-cargo install power_house --version 0.3.3 --features net --locked
+cargo install power_house --version 0.3.4 --features net --locked
 julian --version
 ```
 
 Or use the release container:
 
 ```bash
-docker pull ghcr.io/jrochub/power_house:0.3.3
+docker pull ghcr.io/jrochub/power_house:0.3.4
 ```
 
 ## Create An Identity
@@ -40,6 +40,24 @@ julian key-info "$HOME/.powerhouse/node.key" --json
 
 Never send the private key. Share only the peer ID and public key when
 requesting validator admission.
+
+After admission is approved, create a signed monitoring registration:
+
+```bash
+julian validator-registry create \
+  --key "$HOME/.powerhouse/node.key" \
+  --node-id external-validator-1 \
+  --operator "Operator Name" \
+  --region <region> \
+  --p2p-address /dns4/<host>/tcp/7001/p2p/<peer-id> \
+  --metrics-url http://<monitoring-address>:9100/metrics \
+  --system-metrics-url http://<monitoring-address>:9101/metrics \
+  --output validator.registration.json
+```
+
+The signed record proves control of the claimed identity. It is counted only
+after policy admission and a matching live identity health check. See
+[Signed Validator Registry](validator_registry.md).
 
 ## Start An Observer
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,9 +1,9 @@
 # Power-House Operations Guide
 
-Release scope: Power House v0.3.3.
+Release scope: Power House v0.3.4.
 
 This guide documents the retained boot-node, JULIAN network, and blob-service
-operations in v0.3.3. For the current three-validator native RPC topology and
+operations in v0.3.4. For the current three-validator native RPC topology and
 public HTTPS edge, use
 [Production RPC Deployment](production_rpc_deployment.md). Commands here
 assume explicit operator control so each change remains auditable.

--- a/docs/orbital_observatory.md
+++ b/docs/orbital_observatory.md
@@ -1,6 +1,6 @@
 # MFENX Orbital Observatory
 
-Release surface: Power House v0.3.3.
+Release surface: Power House v0.3.4.
 
 `mfenx.com` presents Power House as an interactive planetary proof
 observatory. It combines live celestial telemetry, world time, published proof

--- a/docs/pha_spec.md
+++ b/docs/pha_spec.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Normative for Power House v0.3.3.
+Normative for Power House v0.3.4.
 
 This document defines the portable Power House Archive v1 JSON format. The
 schema identifier is:

--- a/docs/prior_art_review.md
+++ b/docs/prior_art_review.md
@@ -1,6 +1,6 @@
 # Prior-Art Review
 
-Status: active technical review for Power House v0.3.3.
+Status: active technical review for Power House v0.3.4.
 
 ## Question Under Review
 

--- a/docs/production_rpc_deployment.md
+++ b/docs/production_rpc_deployment.md
@@ -1,6 +1,6 @@
 # LAX MFENX RPC Production Deployment
 
-Release scope: Power House v0.3.3.
+Release scope: Power House v0.3.4.
 
 The retired VPS hosts should not be restored. Replace them with a reproducible
 three-validator deployment whose membership, keys, genesis balances, service
@@ -17,6 +17,7 @@ configuration, and public edge are independently verifiable.
 - Weekly Droplet backups plus application-level state backups.
 - External probes comparing finalized height, block hash, and state root.
 - Prometheus, Alertmanager, blackbox exporter, node exporter, and Grafana.
+- Signed validator identity registry with dynamic Prometheus discovery.
 - A public status API at `/network-status.json`.
 
 Do not expose TCP `8545`, metrics, blob storage, or SSH directly to the
@@ -122,9 +123,10 @@ scripts/generate_rpc_cluster.py \
   --fund 0xYOUR_GENESIS_ADDRESS:1000000
 ```
 
-The output directory contains consensus private keys. It is intentionally
-created with restrictive permissions and must be encrypted, backed up, and
-kept outside source control.
+The output directory contains consensus private keys plus signed public
+validator registrations and an assembled `validator-registry.json`. It is
+intentionally created with restrictive permissions and must be encrypted,
+backed up, and kept outside source control.
 
 ## Install the cluster
 
@@ -149,7 +151,7 @@ restarts one validator at a time, waits for RPC health, verifies
 Allow validator-tag traffic to TCP `9090`, `9100`, and `9101`, then run:
 
 ```bash
-POWER_HOUSE_RELEASE=0.3.3 \
+POWER_HOUSE_RELEASE=0.3.4 \
 SSH_OPTS="-F /dev/null -o StrictHostKeyChecking=accept-new" \
 scripts/deploy_monitoring_stack.sh \
   root@<validator-1-ipv4> \
@@ -161,6 +163,12 @@ Grafana binds to `127.0.0.1:3000`; open it through an SSH tunnel. Alertmanager
 always delivers to the local journal. Set `PH_SLACK_WEBHOOK_URL` or
 `PH_PAGERDUTY_ROUTING_KEY` in the root-only monitoring alert environment to
 add an external destination.
+
+The deployment enables `powerhouse-validator-registry.timer` on each node.
+Every 15 seconds it verifies signatures and policy admission, checks live
+identity and health, then atomically updates the status state. Only the primary
+monitor uses the generated Prometheus discovery files, but every RPC replica
+can serve the same independently reconciled public status.
 
 The corresponding Terraform declaration is under
 [`infra/terraform/digitalocean`](../infra/terraform/digitalocean/README.md).

--- a/docs/provenance_security.md
+++ b/docs/provenance_security.md
@@ -1,6 +1,6 @@
 # Provenance Security Model
 
-Status: active security statement for Power House v0.3.3.
+Status: active security statement for Power House v0.3.4.
 
 This document defines the integrity boundary for Power House Archive (`.pha`)
 v1, Rootprint v1, and optional external proof attachments.

--- a/docs/research_protocol.md
+++ b/docs/research_protocol.md
@@ -1,6 +1,6 @@
 # Research Protocol
 
-Status: active research and evidence protocol for Power House v0.3.3.
+Status: active research and evidence protocol for Power House v0.3.4.
 
 This document turns Power-House development into a falsifiable research
 program. Scale demonstrations remain useful, but exponent size alone is not a

--- a/docs/rootprint.md
+++ b/docs/rootprint.md
@@ -1,6 +1,6 @@
 # Rootprint v1
 
-Status: normative for Power House v0.3.3.
+Status: normative for Power House v0.3.4.
 
 Rootprint is the primary Power House provenance workflow. It is a deterministic
 directed acyclic graph whose nodes carry `.pha` artifacts and whose edges record

--- a/docs/rpc_operations.md
+++ b/docs/rpc_operations.md
@@ -1,6 +1,6 @@
 # Power-House RPC Operations
 
-Release scope: Power House v0.3.3.
+Release scope: Power House v0.3.4.
 
 Power-House exposes a native-transfer JSON-RPC lane whose blocks and account
 state are finalized by the configured validator quorum. Chain ID `177155` is
@@ -103,6 +103,13 @@ Prometheus exports `native_transactions_accepted_total`,
 `native_blocks_finalized_total`, and `native_sync_blocks_applied_total`.
 It also exports `powerhouse_connected_peers`, which must remain above zero on
 every production validator.
+
+Each validator also exports `powerhouse_node_identity`, binding its node ID,
+libp2p peer ID, Ed25519 public key, and chain ID to the live metrics endpoint.
+The signed validator registry reconciler checks that metric every 15 seconds
+and supplies dynamic Prometheus targets. Public validator totals come from
+fresh, policy-admitted, identity-verified registry state rather than peer
+connection counts. See [Signed Validator Registry](validator_registry.md).
 
 ## Incident response
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,6 +1,6 @@
 # SDKs
 
-Power House v0.3.3 ships matching Rust and zero-dependency Python interfaces
+Power House v0.3.4 ships matching Rust and zero-dependency Python interfaces
 for `.pha` and Rootprint v1.
 
 ## Rust

--- a/docs/security_model.md
+++ b/docs/security_model.md
@@ -1,6 +1,6 @@
 # Sparse Certificate Security Model
 
-Status: active security statement for Power House v0.3.3 sparse formats.
+Status: active security statement for Power House v0.3.4 sparse formats.
 
 This document defines what `PHSPv1`, `PHSMv1`, and `PHCPv1` establish and what
 they do not establish.

--- a/docs/sextillion_proof.md
+++ b/docs/sextillion_proof.md
@@ -1,6 +1,6 @@
 # Sextillion-Scale Verification Certificate
 
-Status: active proof profile for Power House v0.3.3.
+Status: active proof profile for Power House v0.3.4.
 
 Power-House can verify a sum-check claim over a domain larger than one
 sextillion points without enumerating the domain.

--- a/docs/sparse_record.md
+++ b/docs/sparse_record.md
@@ -1,6 +1,6 @@
 # Public Sparse Computation Certificate
 
-Status: active format guide for Power House v0.3.3.
+Status: active format guide for Power House v0.3.4.
 
 Power-House now includes an event-driven sum-check prover for a public seeded
 sparse multilinear polynomial:

--- a/docs/testnet_mainnet.md
+++ b/docs/testnet_mainnet.md
@@ -1,6 +1,6 @@
 # MFENX Testnet To Mainnet Process
 
-Release scope: Power House v0.3.3.
+Release scope: Power House v0.3.4.
 
 Chain metadata currently identifies chain `177155` as active. Future mainnet
 launches or incompatible resets must use this process rather than silently

--- a/docs/validator_registry.md
+++ b/docs/validator_registry.md
@@ -1,0 +1,99 @@
+# Signed Validator Registry
+
+Release scope: Power House v0.3.4.
+
+The validator registry replaces hardcoded monitoring totals with signed,
+policy-admitted, live identity checks. It controls monitoring discovery and
+public health reporting. It does not rewrite an existing chain's persisted
+consensus set or quorum.
+
+## Security Model
+
+A validator registration contains:
+
+- chain ID
+- node ID, operator, and region
+- Ed25519 public key
+- libp2p peer ID and address
+- validator and system metrics endpoints
+- issue and expiration times
+- an Ed25519 signature from the validator identity
+
+Verification requires all of the following:
+
+1. The registration schema and chain ID are correct.
+2. The peer ID is derived from the registered Ed25519 public key.
+3. The libp2p address ends in that peer ID.
+4. The signature covers every registration field.
+5. The registration has not expired.
+6. The public key appears in the active validator policy.
+7. Node ID, peer ID, public key, and metrics endpoint are unique.
+8. The live metrics endpoint reports the same node ID, peer ID, public key,
+   and chain ID.
+
+An ordinary connected peer cannot increase the validator count. A signed but
+unadmitted identity cannot increase it either.
+
+## Create A Registration
+
+Run this on a protected operator machine with the validator key:
+
+```bash
+julian validator-registry create \
+  --key /etc/powerhouse/validator-4.key \
+  --node-id validator-4 \
+  --operator "Example Operator" \
+  --region fra1 \
+  --p2p-address /dns4/validator-4.example/tcp/7001/p2p/<peer-id> \
+  --metrics-url http://validator-4.internal:9100/metrics \
+  --system-metrics-url http://validator-4.internal:9101/metrics \
+  --output validator-4.registration.json
+```
+
+The output contains no private key. Keep metrics endpoints restricted to the
+monitoring network.
+
+## Assemble And Verify
+
+```bash
+julian validator-registry assemble \
+  --registration validator-1.registration.json \
+  --registration validator-2.registration.json \
+  --registration validator-3.registration.json \
+  --policy /etc/powerhouse/native-validators.json \
+  --output /etc/powerhouse/validator-registry.json
+
+julian validator-registry verify \
+  /etc/powerhouse/validator-registry.json \
+  --policy /etc/powerhouse/native-validators.json
+```
+
+The production cluster generator performs these steps automatically.
+
+## Reconciliation
+
+`powerhouse-validator-registry.timer` runs every 15 seconds. Its reconciler:
+
+- verifies every signature and policy admission before changing discovery
+- probes validators concurrently
+- checks the live identity metric against the signed registration
+- writes Prometheus file-discovery and public status state atomically
+- preserves the last known-good discovery files if registry verification fails
+
+The public API reports dynamic `validators_healthy`, `validators_total`,
+`peer_connections`, and `validator_registry` fields. `peer_connections`
+remains a link observation count and is not used as validator membership.
+
+## Adding A Validator
+
+Validator admission is a controlled protocol operation:
+
+1. Approve the validator identity through the network membership process.
+2. Apply the compatible consensus-set transition to every validator.
+3. Obtain and verify the new validator's signed registration.
+4. Assemble and deploy the updated registry.
+5. Confirm live identity and health before advertising the new total.
+
+Do not add an identity only to the monitoring registry and call it a consensus
+validator. Current finalized state must remain compatible with the admitted
+validator set.

--- a/docs/verification_guide.md
+++ b/docs/verification_guide.md
@@ -1,6 +1,6 @@
 # Verification Guide
 
-This guide reproduces the Power House v0.3.3 provenance and proof workflows.
+This guide reproduces the Power House v0.3.4 provenance and proof workflows.
 
 ## Requirements
 

--- a/infra/monitoring/powerhouse-validator-registry.service
+++ b/infra/monitoring/powerhouse-validator-registry.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Power House signed validator registry reconciliation
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/powerhouse/validator-registry.env
+ExecStart=/usr/local/lib/powerhouse/validator_registry.py
+User=root
+Group=root
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/etc/prometheus/file_sd /var/lib/powerhouse/monitoring
+

--- a/infra/monitoring/powerhouse-validator-registry.timer
+++ b/infra/monitoring/powerhouse-validator-registry.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Refresh Power House validator registry health
+
+[Timer]
+OnBootSec=20s
+OnUnitActiveSec=15s
+AccuracySec=1s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/monitoring/prometheus.yml
+++ b/infra/monitoring/prometheus.yml
@@ -12,22 +12,14 @@ alerting:
 
 scrape_configs:
   - job_name: powerhouse
-    static_configs:
-      - targets: ["__NODE1__:9100"]
-        labels: { node: "validator-1", region: "nyc3" }
-      - targets: ["__NODE2__:9100"]
-        labels: { node: "validator-2", region: "sfo3" }
-      - targets: ["__NODE3__:9100"]
-        labels: { node: "validator-3", region: "ams3" }
+    file_sd_configs:
+      - files: ["/etc/prometheus/file_sd/powerhouse-validators.json"]
+        refresh_interval: 15s
 
   - job_name: node
-    static_configs:
-      - targets: ["__NODE1__:9101"]
-        labels: { node: "validator-1", region: "nyc3" }
-      - targets: ["__NODE2__:9101"]
-        labels: { node: "validator-2", region: "sfo3" }
-      - targets: ["__NODE3__:9101"]
-        labels: { node: "validator-3", region: "ams3" }
+    file_sd_configs:
+      - files: ["/etc/prometheus/file_sd/powerhouse-systems.json"]
+        refresh_interval: 15s
 
   - job_name: blackbox-rpc
     metrics_path: /probe

--- a/infra/monitoring/status_api.py
+++ b/infra/monitoring/status_api.py
@@ -9,6 +9,11 @@ from urllib.request import Request, urlopen
 PROMETHEUS_URL = os.environ.get("PROMETHEUS_URL", "http://127.0.0.1:9090")
 RPC_URL = os.environ.get("RPC_URL", "https://rpc.mfenx.com")
 RELEASE = os.environ.get("POWER_HOUSE_RELEASE", "unknown")
+REGISTRY_STATE_PATH = os.environ.get(
+    "VALIDATOR_REGISTRY_STATE",
+    "/var/lib/powerhouse/monitoring/validator-registry-state.json",
+)
+REGISTRY_MAX_AGE_SECONDS = int(os.environ.get("VALIDATOR_REGISTRY_MAX_AGE", "45"))
 
 
 def fetch_json(url, data=None, headers=None):
@@ -41,30 +46,26 @@ def rpc(method):
     return response["result"]
 
 
+def registry_health():
+    with open(REGISTRY_STATE_PATH, encoding="utf-8") as handle:
+        state = json.load(handle)
+    generated = datetime.fromisoformat(state["generated_at"].replace("Z", "+00:00"))
+    age = (datetime.now(timezone.utc) - generated).total_seconds()
+    state["fresh"] = 0 <= age <= REGISTRY_MAX_AGE_SECONDS
+    return state
+
+
 def snapshot():
-    validators = int(
-        query(
-            'count(count by (node) '
-            '(up{job="powerhouse",node=~"validator-[123]"} == 1))'
-        )
-        or 0
-    )
-    systems = int(
-        query(
-            'count(count by (node) '
-            '(up{job="node",node=~"validator-[123]"} == 1))'
-        )
-        or 0
+    registry = registry_health()
+    validators = int(registry.get("validators_healthy", 0))
+    validators_total = int(registry.get("validators_total", 0))
+    systems = sum(
+        1
+        for item in registry.get("validators", [])
+        if item.get("system_metrics_reachable") is True
     )
     rpc_probe = int(query('min(probe_success{job="blackbox-rpc"})') or 0)
-    peers = int(
-        query(
-            'sum(max by (node) '
-            '(powerhouse_connected_peers{'
-            'job="powerhouse",node=~"validator-[123]"}))'
-        )
-        or 0
-    )
+    peers = int(registry.get("peer_link_observations", 0))
     uptime = query(
         'avg_over_time(probe_success{job="blackbox-rpc"}[24h])'
     )
@@ -79,9 +80,16 @@ def snapshot():
     chain_id = int(rpc("eth_chainId"), 16)
     block_height = int(rpc("eth_blockNumber"), 16)
     client = rpc("web3_clientVersion")
-    if validators == 3 and systems == 3 and rpc_probe == 1:
+    registry_ok = registry.get("registry_verified") is True and registry["fresh"]
+    if (
+        registry_ok
+        and validators_total > 0
+        and validators == validators_total
+        and systems == validators_total
+        and rpc_probe == 1
+    ):
         state = "operational"
-    elif validators >= 2 and rpc_probe == 1:
+    elif registry_ok and validators > 0 and rpc_probe == 1:
         state = "degraded"
     else:
         state = "outage"
@@ -106,7 +114,16 @@ def snapshot():
             else None
         ),
         "validators_healthy": validators,
-        "validators_total": 3,
+        "validators_total": validators_total,
+        "validator_registry": {
+            "fresh": registry["fresh"],
+            "identity_verified": sum(
+                1
+                for item in registry.get("validators", [])
+                if item.get("identity_verified") is True
+            ),
+            "verified": registry.get("registry_verified") is True,
+        },
     }
 
 

--- a/infra/monitoring/validator_registry.py
+++ b/infra/monitoring/validator_registry.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Verify signed validator registrations and publish health/discovery state."""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import time
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+
+STATE_SCHEMA = "power-house-validator-registry-health-v1"
+IDENTITY_METRIC = re.compile(
+    r'^powerhouse_node_identity\{(?P<labels>.+)\}\s+(?P<value>[0-9.eE+-]+)$'
+)
+LABEL = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)="((?:\\.|[^"])*)"')
+SIMPLE_METRIC = re.compile(
+    r"^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)\s+(?P<value>[0-9.eE+-]+)$"
+)
+MAX_METRICS_BYTES = 2 * 1024 * 1024
+
+
+class RejectRedirects(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise RuntimeError(f"metrics endpoint redirect rejected: HTTP {code}")
+
+
+def arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=Path("/etc/powerhouse/validator-registry.json"),
+    )
+    parser.add_argument(
+        "--policy",
+        type=Path,
+        default=Path("/etc/powerhouse/native-validators.json"),
+    )
+    parser.add_argument("--binary", type=Path, default=Path("/usr/local/bin/julian"))
+    parser.add_argument(
+        "--state",
+        type=Path,
+        default=Path("/var/lib/powerhouse/monitoring/validator-registry-state.json"),
+    )
+    parser.add_argument(
+        "--powerhouse-discovery",
+        type=Path,
+        default=Path("/etc/prometheus/file_sd/powerhouse-validators.json"),
+    )
+    parser.add_argument(
+        "--node-discovery",
+        type=Path,
+        default=Path("/etc/prometheus/file_sd/powerhouse-systems.json"),
+    )
+    parser.add_argument("--timeout", type=float, default=5.0)
+    return parser.parse_args()
+
+
+def atomic_json(path: Path, value: object, mode: int = 0o640) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def verify_registry(args: argparse.Namespace, now: int) -> dict:
+    process = subprocess.run(
+        [
+            str(args.binary),
+            "validator-registry",
+            "verify",
+            str(args.registry),
+            "--policy",
+            str(args.policy),
+            "--now",
+            str(now),
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=max(args.timeout * 2, 10),
+    )
+    if process.returncode:
+        detail = process.stderr.strip() or process.stdout.strip() or "verification failed"
+        raise RuntimeError(detail)
+    verified = json.loads(process.stdout)
+    if verified.get("verified") is not True:
+        raise RuntimeError("validator verifier did not return verified=true")
+    return verified
+
+
+def decode_label(value: str) -> str:
+    return (
+        value.replace(r"\\", "\0")
+        .replace(r"\"", '"')
+        .replace(r"\n", "\n")
+        .replace("\0", "\\")
+    )
+
+
+def parse_metrics(body: str) -> tuple[dict[str, str] | None, dict[str, float]]:
+    identity = None
+    metrics: dict[str, float] = {}
+    for line in body.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        identity_match = IDENTITY_METRIC.fullmatch(line)
+        if identity_match:
+            labels = {
+                name: decode_label(value)
+                for name, value in LABEL.findall(identity_match.group("labels"))
+            }
+            if float(identity_match.group("value")) == 1:
+                identity = labels
+            continue
+        metric_match = SIMPLE_METRIC.fullmatch(line)
+        if metric_match:
+            metrics[metric_match.group("name")] = float(metric_match.group("value"))
+    return identity, metrics
+
+
+def fetch(url: str, timeout: float) -> str:
+    request = Request(url, headers={"User-Agent": "power-house-validator-registry/1"})
+    with build_opener(RejectRedirects).open(request, timeout=timeout) as response:
+        if response.status != 200:
+            raise RuntimeError(f"HTTP {response.status}")
+        body = response.read(MAX_METRICS_BYTES + 1)
+        if len(body) > MAX_METRICS_BYTES:
+            raise RuntimeError("metrics response exceeds 2 MiB")
+        return body.decode("utf-8", "replace")
+
+
+def check_validator(registration: dict, timeout: float) -> dict:
+    result = {
+        "node_id": registration["node_id"],
+        "operator": registration["operator"],
+        "region": registration["region"],
+        "peer_id": registration["peer_id"],
+        "public_key_b64": registration["public_key_b64"],
+        "identity_verified": False,
+        "metrics_reachable": False,
+        "system_metrics_reachable": registration.get("system_metrics_url") is None,
+        "peer_links": 0,
+        "healthy": False,
+        "error": None,
+    }
+    errors = []
+    try:
+        body = fetch(registration["metrics_url"], timeout)
+        result["metrics_reachable"] = True
+        identity, metrics = parse_metrics(body)
+        expected = {
+            "node_id": registration["node_id"],
+            "peer_id": registration["peer_id"],
+            "public_key_b64": registration["public_key_b64"],
+            "chain_id": str(registration["chain_id"]),
+        }
+        if identity != expected:
+            errors.append("live identity metric does not match signed registration")
+        else:
+            result["identity_verified"] = True
+        peers = metrics.get("powerhouse_connected_peers")
+        if peers is None or peers < 0 or not peers.is_integer():
+            errors.append("connected peer metric is missing or invalid")
+        else:
+            result["peer_links"] = int(peers)
+    except Exception as exc:
+        errors.append(f"validator metrics unavailable: {exc}")
+
+    system_url = registration.get("system_metrics_url")
+    if system_url:
+        try:
+            fetch(system_url, timeout)
+            result["system_metrics_reachable"] = True
+        except Exception as exc:
+            errors.append(f"system metrics unavailable: {exc}")
+
+    result["healthy"] = (
+        result["identity_verified"]
+        and result["metrics_reachable"]
+        and result["system_metrics_reachable"]
+    )
+    if errors:
+        result["error"] = "; ".join(errors)
+    return result
+
+
+def discovery_entry(registration: dict, endpoint: str) -> dict:
+    parsed = urlsplit(endpoint)
+    return {
+        "targets": [parsed.netloc],
+        "labels": {
+            "node": registration["node_id"],
+            "operator": registration["operator"],
+            "region": registration["region"],
+            "peer_id": registration["peer_id"],
+            "public_key_b64": registration["public_key_b64"],
+        },
+    }
+
+
+def reconcile(args: argparse.Namespace) -> dict:
+    now = int(time.time())
+    generated_at = datetime.now(timezone.utc).isoformat()
+    try:
+        verified = verify_registry(args, now)
+    except Exception as exc:
+        state = {
+            "schema": STATE_SCHEMA,
+            "generated_at": generated_at,
+            "registry_verified": False,
+            "validators_total": 0,
+            "validators_healthy": 0,
+            "peer_link_observations": 0,
+            "validators": [],
+            "error": str(exc),
+        }
+        atomic_json(args.state, state)
+        raise
+
+    registrations = verified["registrations"]
+    with ThreadPoolExecutor(max_workers=min(len(registrations), 16)) as executor:
+        validators = list(
+            executor.map(lambda item: check_validator(item, args.timeout), registrations)
+        )
+
+    powerhouse_discovery = [
+        discovery_entry(item, item["metrics_url"]) for item in registrations
+    ]
+    node_discovery = [
+        discovery_entry(item, item["system_metrics_url"])
+        for item in registrations
+        if item.get("system_metrics_url")
+    ]
+    state = {
+        "schema": STATE_SCHEMA,
+        "chain_id": verified["chain_id"],
+        "generated_at": generated_at,
+        "registry_verified": True,
+        "validators_total": len(validators),
+        "validators_healthy": sum(item["healthy"] for item in validators),
+        "peer_link_observations": sum(item["peer_links"] for item in validators),
+        "validators": validators,
+        "error": None,
+    }
+    atomic_json(args.powerhouse_discovery, powerhouse_discovery)
+    atomic_json(args.node_discovery, node_discovery)
+    atomic_json(args.state, state)
+    return state
+
+
+def main() -> int:
+    args = arguments()
+    try:
+        state = reconcile(args)
+    except Exception as exc:
+        print(f"validator registry reconciliation failed: {exc}")
+        return 2
+    print(
+        "validator registry reconciled: "
+        f"{state['validators_healthy']}/{state['validators_total']} healthy"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/publicpower/app.css
+++ b/publicpower/app.css
@@ -1856,7 +1856,7 @@ body.proof-verified .proof-event b {
   }
 }
 
-/* v0.3.3 Observatory command surface */
+/* v0.3.4 Observatory command surface */
 :root {
   --mode-color: #45ddd2;
   --top: 68px;

--- a/publicpower/app.js
+++ b/publicpower/app.js
@@ -2014,7 +2014,7 @@ async function refreshNetworkStatus() {
     el.networkState.textContent = networkState.toUpperCase();
     el.networkConsoleState.textContent = networkState.toUpperCase();
     el.networkBlock.textContent = Number(data.block_height).toLocaleString("en-US");
-    el.networkValidators.textContent = `${healthy} / ${Number(data.validators_total) || 3}`;
+    el.networkValidators.textContent = `${healthy} / ${Number(data.validators_total) || 0}`;
     el.networkPeers.textContent = Number(data.peer_connections).toLocaleString("en-US");
     updateNetworkNodeStates(healthy);
   } catch {

--- a/publicpower/index.html
+++ b/publicpower/index.html
@@ -79,7 +79,7 @@
       </div>
       <div><span>CHAIN</span><b>177155</b></div>
       <div><span>BLOCK</span><b id="network-block">--</b></div>
-      <div><span>VALIDATORS</span><b id="network-validators">-- / 3</b></div>
+      <div><span>VALIDATORS</span><b id="network-validators">-- / --</b></div>
       <div><span>PEERS</span><b id="network-peers">--</b></div>
     </section>
 
@@ -123,7 +123,7 @@
       </button>
 
       <div class="rail-status" aria-label="Release state">
-        <div><span>RELEASE</span><b>v0.3.3</b></div>
+        <div><span>RELEASE</span><b>v0.3.4</b></div>
         <div><span>CORE</span><b>DETERMINISTIC</b></div>
       </div>
     </aside>
@@ -294,7 +294,7 @@
       <div class="evaluation-links">
         <a href="https://github.com/JROChub/power_house/blob/main/docs/verification_guide.md">REPRODUCE</a>
         <a href="https://github.com/JROChub/power_house/blob/main/docs/security_model.md">SECURITY MODEL</a>
-        <a href="https://crates.io/crates/power_house">CRATE v0.3.3</a>
+        <a href="https://crates.io/crates/power_house">CRATE v0.3.4</a>
       </div>
     </aside>
 
@@ -335,7 +335,7 @@
         <div><span>CLAIM</span><b id="claim-value">WAITING</b></div>
         <div><span>DIGEST</span><b id="digest-value">PENDING</b></div>
         <div><span>MODE</span><b id="mode-value">ROOTPRINT</b></div>
-        <div><span>RELEASE</span><b>v0.3.3</b></div>
+        <div><span>RELEASE</span><b>v0.3.4</b></div>
       </div>
     </section>
 

--- a/publicpower/status.html
+++ b/publicpower/status.html
@@ -17,7 +17,7 @@
       <img src="assets/powerhouse-logo.png" alt="">
       <span><b>MFENX</b><small>POWER HOUSE NETWORK CONTROL</small></span>
     </a>
-    <div class="release"><span>RELEASE</span><b>v0.3.3</b></div>
+    <div class="release"><span>RELEASE</span><b>v0.3.4</b></div>
   </header>
 
   <main>
@@ -38,8 +38,8 @@
       </article>
       <article>
         <span>VALIDATORS</span>
-        <b id="validators">-- / 3</b>
-        <small>NEW YORK / SAN FRANCISCO / AMSTERDAM</small>
+        <b id="validators">-- / --</b>
+        <small id="validator-identity">SIGNED REGISTRY CHECKING</small>
       </article>
       <article>
         <span>BLOCK HEIGHT</span>

--- a/publicpower/status.js
+++ b/publicpower/status.js
@@ -32,6 +32,10 @@ async function refreshStatus() {
     );
     setText("rpc", data.rpc?.reachable ? "ONLINE" : "UNAVAILABLE");
     setText("validators", `${data.validators_healthy} / ${data.validators_total}`);
+    document.querySelector("#validator-identity").textContent =
+      data.validator_registry?.verified && data.validator_registry?.fresh
+        ? `${data.validator_registry.identity_verified} IDENTITIES VERIFIED`
+        : "SIGNED REGISTRY UNAVAILABLE";
     setText("block", Number(data.block_height).toLocaleString("en-US"));
     setText("peers", Number(data.peer_connections).toLocaleString("en-US"));
     setText(

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -35,6 +35,7 @@ ACTIVE_DOCS = [
     "docs/sextillion_proof.md",
     "docs/sparse_record.md",
     "docs/testnet_mainnet.md",
+    "docs/validator_registry.md",
     "docs/verification_guide.md",
     "sdk/python/README.md",
 ]

--- a/scripts/check_rustdoc_links.py
+++ b/scripts/check_rustdoc_links.py
@@ -19,6 +19,7 @@ EXPECTED_API_PAGES = (
     "sparse_sumcheck/struct.CommittedSparsePolynomial.html",
     "sparse_sumcheck/struct.CommittedSparseProof.html",
     "julian/struct.ProofLedger.html",
+    "net/validator_registry/struct.ValidatorRegistry.html",
 )
 
 

--- a/scripts/deploy_monitoring_stack.sh
+++ b/scripts/deploy_monitoring_stack.sh
@@ -8,6 +8,7 @@ fi
 
 ROOT="$(cd -- "$(dirname -- "$0")/.." && pwd)"
 HOSTS=("$@")
+VALIDATOR_REGISTRY="${VALIDATOR_REGISTRY:-$ROOT/deployment/generated/mfenx-production/validator-registry.json}"
 SSH_ARGS=()
 if [[ -n "${SSH_OPTS:-}" ]]; then
   read -r -a SSH_ARGS <<<"$SSH_OPTS"
@@ -18,15 +19,10 @@ host_address() {
 }
 
 NODE1=$(host_address "${HOSTS[0]}")
-NODE2=$(host_address "${HOSTS[1]}")
-NODE3=$(host_address "${HOSTS[2]}")
-TEMP_CONFIG=$(mktemp)
-trap 'rm -f "$TEMP_CONFIG"' EXIT
-sed \
-  -e "s/__NODE1__/$NODE1/g" \
-  -e "s/__NODE2__/$NODE2/g" \
-  -e "s/__NODE3__/$NODE3/g" \
-  "$ROOT/infra/monitoring/prometheus.yml" >"$TEMP_CONFIG"
+[[ -f "$VALIDATOR_REGISTRY" ]] || {
+  echo "signed validator registry not found: $VALIDATOR_REGISTRY" >&2
+  exit 1
+}
 
 for index in 0 1 2; do
   host="${HOSTS[$index]}"
@@ -36,18 +32,27 @@ for index in 0 1 2; do
   ssh "${SSH_ARGS[@]}" "$host" \
     "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y prometheus-node-exporter"
   ssh "${SSH_ARGS[@]}" "$host" \
-    "install -d -m 0750 /etc/powerhouse /usr/local/lib/powerhouse"
+    "install -d -m 0750 /etc/powerhouse /usr/local/lib/powerhouse /var/lib/powerhouse/monitoring && install -d -m 0755 /etc/prometheus/file_sd"
   scp "${SSH_ARGS[@]}" "$ROOT/infra/monitoring/status_api.py" \
     "$host:/usr/local/lib/powerhouse/status_api.py"
+  scp "${SSH_ARGS[@]}" "$ROOT/infra/monitoring/validator_registry.py" \
+    "$host:/usr/local/lib/powerhouse/validator_registry.py"
   scp "${SSH_ARGS[@]}" "$ROOT/infra/monitoring/powerhouse-status-api.service" \
     "$host:/etc/systemd/system/powerhouse-status-api.service"
+  scp "${SSH_ARGS[@]}" "$ROOT/infra/monitoring/powerhouse-validator-registry.service" \
+    "$host:/etc/systemd/system/powerhouse-validator-registry.service"
+  scp "${SSH_ARGS[@]}" "$ROOT/infra/monitoring/powerhouse-validator-registry.timer" \
+    "$host:/etc/systemd/system/powerhouse-validator-registry.timer"
+  scp "${SSH_ARGS[@]}" "$VALIDATOR_REGISTRY" \
+    "$host:/etc/powerhouse/validator-registry.json"
   scp "${SSH_ARGS[@]}" "$ROOT/infra/monitoring/nginx-mfenx-rpc.conf" \
     "$host:/etc/nginx/sites-available/mfenx-rpc"
   ssh "${SSH_ARGS[@]}" "$host" env \
     "PROMETHEUS_URL=$prometheus_url" \
     "POWER_HOUSE_RELEASE=${POWER_HOUSE_RELEASE:?set POWER_HOUSE_RELEASE}" bash -s <<'REMOTE'
 set -euo pipefail
-chmod 0755 /usr/local/lib/powerhouse/status_api.py
+chmod 0755 /usr/local/lib/powerhouse/status_api.py /usr/local/lib/powerhouse/validator_registry.py
+chmod 0640 /etc/powerhouse/validator-registry.json
 cat >/etc/default/prometheus-node-exporter <<'EOF'
 ARGS="--web.listen-address=0.0.0.0:9101"
 EOF
@@ -55,14 +60,21 @@ cat >/etc/powerhouse/status-api.env <<EOF
 PROMETHEUS_URL=$PROMETHEUS_URL
 RPC_URL=https://rpc.mfenx.com
 POWER_HOUSE_RELEASE=$POWER_HOUSE_RELEASE
+VALIDATOR_REGISTRY_STATE=/var/lib/powerhouse/monitoring/validator-registry-state.json
+VALIDATOR_REGISTRY_MAX_AGE=45
 EOF
 chmod 0640 /etc/powerhouse/status-api.env
 ln -sfn /etc/nginx/sites-available/mfenx-rpc /etc/nginx/sites-enabled/mfenx-rpc
 rm -f /etc/nginx/sites-enabled/default
 nginx -t
 systemctl daemon-reload
-systemctl enable --now prometheus-node-exporter powerhouse-status-api
-systemctl restart prometheus-node-exporter powerhouse-status-api
+systemctl enable --now \
+  prometheus-node-exporter \
+  powerhouse-validator-registry.timer \
+  powerhouse-status-api
+systemctl restart prometheus-node-exporter
+systemctl start powerhouse-validator-registry.service
+systemctl restart powerhouse-status-api
 systemctl reload nginx
 REMOTE
 done
@@ -89,7 +101,8 @@ install -d -m 0755 \
   /usr/local/lib/powerhouse
 REMOTE
 
-scp "${SSH_ARGS[@]}" "$TEMP_CONFIG" "$monitor:/etc/prometheus/prometheus.yml"
+scp "${SSH_ARGS[@]}" "$ROOT/infra/monitoring/prometheus.yml" \
+  "$monitor:/etc/prometheus/prometheus.yml"
 scp "${SSH_ARGS[@]}" "$ROOT/infra/monitoring/powerhouse-alerts.yml" \
   "$monitor:/etc/prometheus/powerhouse-alerts.yml"
 scp "${SSH_ARGS[@]}" "$ROOT/infra/monitoring/blackbox.yml" \

--- a/scripts/deploy_rpc_cluster.sh
+++ b/scripts/deploy_rpc_cluster.sh
@@ -30,6 +30,7 @@ required_bundle_files=(
   native-validators.json
   powerhouse-common.env
   stake_registry.json
+  validator-registry.json
 )
 
 [[ -d "$BUNDLE" ]] || {
@@ -125,6 +126,8 @@ deploy_node() {
     "$host:/etc/powerhouse/.native-validators.json.upload"
   scp "${SSH_ARGS[@]}" "$BUNDLE/stake_registry.json" \
     "$host:/etc/powerhouse/.stake_registry.json.upload"
+  scp "${SSH_ARGS[@]}" "$BUNDLE/validator-registry.json" \
+    "$host:/etc/powerhouse/.validator-registry.json.upload"
 
   ssh "${SSH_ARGS[@]}" "$host" env "NODE=$node" bash -s <<'REMOTE'
 set -euo pipefail
@@ -134,6 +137,7 @@ install -m 0640 /etc/powerhouse/.powerhouse-common.env.upload /etc/powerhouse/po
 install -m 0640 "/etc/powerhouse/.powerhouse-$NODE.env.upload" "/etc/powerhouse/powerhouse-$NODE.env"
 install -m 0600 "/etc/powerhouse/.$NODE.key.upload" "/etc/powerhouse/$NODE.key"
 install -m 0640 /etc/powerhouse/.native-validators.json.upload /etc/powerhouse/native-validators.json
+install -m 0640 /etc/powerhouse/.validator-registry.json.upload /etc/powerhouse/validator-registry.json
 
 if [[ -e "$state/native_chain_state.json" ]]; then
   echo "preserving finalized native chain state for $NODE"
@@ -151,7 +155,8 @@ rm -f \
   "/etc/powerhouse/.powerhouse-$NODE.env.upload" \
   "/etc/powerhouse/.$NODE.key.upload" \
   /etc/powerhouse/.native-validators.json.upload \
-  /etc/powerhouse/.stake_registry.json.upload
+  /etc/powerhouse/.stake_registry.json.upload \
+  /etc/powerhouse/.validator-registry.json.upload
 
 systemctl daemon-reload
 systemd-analyze verify "/etc/systemd/system/powerhouse-node@.service"

--- a/scripts/generate_rpc_cluster.py
+++ b/scripts/generate_rpc_cluster.py
@@ -13,10 +13,12 @@ import secrets
 import stat
 import subprocess
 import sys
+import time
 
 
 VALIDATOR_COUNT = 3
 DEFAULT_CHAIN_ID = 177155
+DEFAULT_REGIONS = ["nyc3", "sfo3", "ams3"]
 EVM_ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
 
 
@@ -94,6 +96,71 @@ def inspect_key(binary: Path, key_path: Path) -> dict[str, str]:
     if set(info) != {"peer_id", "public_key_b64"}:
         fail("key-info returned an unexpected payload")
     return info
+
+
+def create_validator_registry(
+    binary: Path,
+    output: Path,
+    hosts: list[str],
+    keys: list[dict[str, str]],
+    chain_id: int,
+) -> None:
+    issued_at = int(time.time())
+    valid_until = issued_at + 365 * 24 * 60 * 60
+    registrations = []
+    for index, host in enumerate(hosts):
+        registration = output / f"validator-{index + 1}.registration.json"
+        p2p_address = (
+            f"{multiaddr_host(host)}/tcp/7001/p2p/{keys[index]['peer_id']}"
+        )
+        subprocess.run(
+            [
+                str(binary),
+                "validator-registry",
+                "create",
+                "--key",
+                str(output / f"validator-{index + 1}.key"),
+                "--node-id",
+                f"validator-{index + 1}",
+                "--operator",
+                "MFENX LLC",
+                "--region",
+                DEFAULT_REGIONS[index],
+                "--p2p-address",
+                p2p_address,
+                "--metrics-url",
+                f"http://{host}:9100/metrics",
+                "--system-metrics-url",
+                f"http://{host}:9101/metrics",
+                "--chain-id",
+                str(chain_id),
+                "--issued-at",
+                str(issued_at),
+                "--valid-until",
+                str(valid_until),
+                "--output",
+                str(registration),
+            ],
+            check=True,
+        )
+        os.chmod(registration, 0o640)
+        registrations.append(registration)
+
+    command = [
+        str(binary),
+        "validator-registry",
+        "assemble",
+        "--policy",
+        str(output / "native-validators.json"),
+        "--chain-id",
+        str(chain_id),
+        "--output",
+        str(output / "validator-registry.json"),
+    ]
+    for registration in registrations:
+        command.extend(["--registration", str(registration)])
+    subprocess.run(command, check=True)
+    os.chmod(output / "validator-registry.json", 0o640)
 
 
 def write_private(path: Path, data: bytes) -> None:
@@ -197,6 +264,7 @@ def main() -> int:
         output / "native-validators.json",
         json.dumps(policy, indent=2, sort_keys=True) + "\n",
     )
+    create_validator_registry(binary, output, args.host, key_info, args.chain_id)
     write_text(output / "powerhouse-common.env", render_common(args.chain_id))
 
     for index in range(VALIDATOR_COUNT):
@@ -214,6 +282,7 @@ def main() -> int:
         "chain_id": args.chain_id,
         "hosts": args.host,
         "quorum": 2,
+        "validator_registry": "validator-registry.json",
         "validators": [
             {
                 "name": f"validator-{index + 1}",

--- a/scripts/test_cli.sh
+++ b/scripts/test_cli.sh
@@ -36,6 +36,7 @@ expect_output "execute-burn-intents" migration --help
 expect_output "settle-file" rollup --help
 expect_output "encrypted Ed25519 identity" keygen --help
 expect_output "libp2p peer ID" key-info --help
+expect_output "signed by the validator identity" validator-registry --help
 
 KEY_INFO=$("$JULIAN" key-info ed25519://cli-test-validator --json)
 python3 -c '

--- a/scripts/test_generate_rpc_cluster.py
+++ b/scripts/test_generate_rpc_cluster.py
@@ -45,12 +45,31 @@ def main() -> None:
         manifest = json.loads((output / "cluster-manifest.json").read_text())
         policy = json.loads((output / "native-validators.json").read_text())
         registry = json.loads((output / "stake_registry.json").read_text())
+        validator_registry = json.loads(
+            (output / "validator-registry.json").read_text()
+        )
         assert manifest["chain_id"] == 177155
+        assert manifest["validator_registry"] == "validator-registry.json"
         assert len({item["peer_id"] for item in manifest["validators"]}) == 3
         assert len({item["public_key_b64"] for item in manifest["validators"]}) == 3
         assert policy["allowlist"] == [
             item["public_key_b64"] for item in manifest["validators"]
         ]
+        assert validator_registry["chain_id"] == 177155
+        assert len(validator_registry["registrations"]) == 3
+        subprocess.run(
+            [
+                str(BINARY),
+                "validator-registry",
+                "verify",
+                str(output / "validator-registry.json"),
+                "--policy",
+                str(output / "native-validators.json"),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
         assert (
             registry["accounts"][
                 "0x4a62316623ad457f02cdc5d997ded67a383ec569"

--- a/scripts/test_status_registry.py
+++ b/scripts/test_status_registry.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STATUS_API = ROOT / "infra" / "monitoring" / "status_api.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("powerhouse_status_api", STATUS_API)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def registry_state(generated_at: str) -> dict:
+    validators = [
+        {
+            "node_id": f"validator-{index}",
+            "healthy": True,
+            "identity_verified": True,
+            "system_metrics_reachable": True,
+            "peer_links": 3,
+        }
+        for index in range(1, 5)
+    ]
+    return {
+        "schema": "power-house-validator-registry-health-v1",
+        "chain_id": 177155,
+        "generated_at": generated_at,
+        "registry_verified": True,
+        "validators_total": 4,
+        "validators_healthy": 4,
+        "peer_link_observations": 12,
+        "validators": validators,
+        "error": None,
+    }
+
+
+def main() -> None:
+    prometheus = (ROOT / "infra" / "monitoring" / "prometheus.yml").read_text()
+    assert "/etc/prometheus/file_sd/powerhouse-validators.json" in prometheus
+    assert "/etc/prometheus/file_sd/powerhouse-systems.json" in prometheus
+    assert "__NODE" not in prometheus
+    deployment = (ROOT / "scripts" / "deploy_monitoring_stack.sh").read_text()
+    assert "powerhouse-validator-registry.timer" in deployment
+    assert "validator-registry.json" in deployment
+    website = (ROOT / "publicpower" / "app.js").read_text()
+    assert "validators_total) || 3" not in website
+
+    module = load_module()
+    now = datetime.now(timezone.utc)
+    with tempfile.TemporaryDirectory(prefix="powerhouse-status-registry-") as temp:
+        state_path = Path(temp) / "state.json"
+        module.REGISTRY_STATE_PATH = str(state_path)
+        module.query = lambda expression: (
+            1.0 if "probe_success" in expression and "avg_over_time" not in expression else 0.999
+        )
+        module.fetch_json = lambda url, data=None, headers=None: {
+            "data": {"startTime": (now - timedelta(days=2)).isoformat()}
+        }
+        module.rpc = lambda method: {
+            "eth_chainId": hex(177155),
+            "eth_blockNumber": hex(42),
+            "web3_clientVersion": "power-house/test",
+        }[method]
+
+        state_path.write_text(json.dumps(registry_state(now.isoformat())))
+        snapshot = module.snapshot()
+        assert snapshot["status"] == "operational"
+        assert snapshot["validators_healthy"] == 4
+        assert snapshot["validators_total"] == 4
+        assert snapshot["peer_connections"] == 12
+        assert snapshot["validator_registry"] == {
+            "fresh": True,
+            "identity_verified": 4,
+            "verified": True,
+        }
+
+        stale = now - timedelta(minutes=5)
+        state_path.write_text(json.dumps(registry_state(stale.isoformat())))
+        snapshot = module.snapshot()
+        assert snapshot["status"] == "outage"
+        assert snapshot["validator_registry"]["fresh"] is False
+
+    print("test_status_registry: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_validator_registry.py
+++ b/scripts/test_validator_registry.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BINARY = ROOT / "target" / "debug" / "julian"
+RECONCILER = ROOT / "infra" / "monitoring" / "validator_registry.py"
+
+
+class MetricsServer:
+    def __init__(self) -> None:
+        self.body = ""
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path != "/metrics":
+                    self.send_error(404)
+                    return
+                encoded = owner.body.encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; version=0.0.4")
+                self.send_header("Content-Length", str(len(encoded)))
+                self.end_headers()
+                self.wfile.write(encoded)
+
+            def log_message(self, format, *args):
+                return
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.server.server_port}/metrics"
+
+    def close(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+
+def run(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(BINARY), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def identity(key: Path) -> dict:
+    return json.loads(run("key-info", str(key), "--json").stdout)
+
+
+def metric_body(node: dict, peer_links: int = 2) -> str:
+    return (
+        "# TYPE powerhouse_node_identity gauge\n"
+        "powerhouse_node_identity{"
+        f'node_id="{node["node_id"]}",'
+        f'peer_id="{node["peer_id"]}",'
+        f'public_key_b64="{node["public_key_b64"]}",'
+        'chain_id="177155"} 1\n'
+        "# TYPE powerhouse_connected_peers gauge\n"
+        f"powerhouse_connected_peers {peer_links}\n"
+    )
+
+
+def main() -> None:
+    now = int(time.time())
+    servers = [MetricsServer() for _ in range(3)]
+    try:
+        with tempfile.TemporaryDirectory(prefix="powerhouse-registry-test-") as temp:
+            base = Path(temp)
+            registrations = []
+            nodes = []
+            for index, server in enumerate(servers, start=1):
+                key = base / f"validator-{index}.key"
+                key.write_bytes(bytes([index]) * 32)
+                info = identity(key)
+                node = {
+                    "node_id": f"validator-{index}",
+                    "region": ["nyc3", "sfo3", "ams3"][index - 1],
+                    **info,
+                }
+                nodes.append(node)
+                registration = base / f"validator-{index}.registration.json"
+                run(
+                    "validator-registry",
+                    "create",
+                    "--key",
+                    str(key),
+                    "--node-id",
+                    node["node_id"],
+                    "--operator",
+                    "MFENX LLC",
+                    "--region",
+                    node["region"],
+                    "--p2p-address",
+                    f"/ip4/127.0.0.1/tcp/{7000 + index}/p2p/{info['peer_id']}",
+                    "--metrics-url",
+                    server.url,
+                    "--system-metrics-url",
+                    server.url,
+                    "--issued-at",
+                    str(now),
+                    "--valid-until",
+                    str(now + 3600),
+                    "--output",
+                    str(registration),
+                )
+                registrations.append(registration)
+                server.body = metric_body(node)
+
+            policy = base / "native-validators.json"
+            policy.write_text(
+                json.dumps(
+                    {
+                        "allowlist": [node["public_key_b64"] for node in nodes],
+                        "backend": "static",
+                    }
+                )
+            )
+            registry = base / "validator-registry.json"
+            assemble = [
+                "validator-registry",
+                "assemble",
+                "--policy",
+                str(policy),
+                "--output",
+                str(registry),
+            ]
+            for registration in registrations:
+                assemble.extend(["--registration", str(registration)])
+            run(*assemble)
+            original_registry = registry.read_text()
+
+            verified = json.loads(
+                run(
+                    "validator-registry",
+                    "verify",
+                    str(registry),
+                    "--policy",
+                    str(policy),
+                    "--now",
+                    str(now),
+                    "--json",
+                ).stdout
+            )
+            assert verified["verified"] is True
+            assert verified["validators_verified"] == 3
+
+            state = base / "state.json"
+            powerhouse_discovery = base / "powerhouse.json"
+            node_discovery = base / "systems.json"
+            reconcile = [
+                sys.executable,
+                str(RECONCILER),
+                "--registry",
+                str(registry),
+                "--policy",
+                str(policy),
+                "--binary",
+                str(BINARY),
+                "--state",
+                str(state),
+                "--powerhouse-discovery",
+                str(powerhouse_discovery),
+                "--node-discovery",
+                str(node_discovery),
+                "--timeout",
+                "1",
+            ]
+            subprocess.run(reconcile, check=True, capture_output=True, text=True)
+            health = json.loads(state.read_text())
+            assert health["registry_verified"] is True
+            assert health["validators_total"] == 3
+            assert health["validators_healthy"] == 3
+            assert health["peer_link_observations"] == 6
+            assert all(item["identity_verified"] for item in health["validators"])
+            assert len(json.loads(powerhouse_discovery.read_text())) == 3
+            assert len(json.loads(node_discovery.read_text())) == 3
+
+            servers[1].body = metric_body(
+                {**nodes[1], "peer_id": nodes[0]["peer_id"]}
+            )
+            subprocess.run(reconcile, check=True, capture_output=True, text=True)
+            health = json.loads(state.read_text())
+            assert health["registry_verified"] is True
+            assert health["validators_healthy"] == 2
+            assert health["validators"][1]["identity_verified"] is False
+            servers[1].body = metric_body(nodes[1])
+
+            last_good_discovery = powerhouse_discovery.read_text()
+            tampered = json.loads(registry.read_text())
+            tampered["registrations"][0]["region"] = "fra1"
+            registry.write_text(json.dumps(tampered))
+            failed = subprocess.run(reconcile, check=False, capture_output=True, text=True)
+            assert failed.returncode == 2
+            health = json.loads(state.read_text())
+            assert health["registry_verified"] is False
+            assert powerhouse_discovery.read_text() == last_good_discovery
+
+            registry.write_text(original_registry)
+            expired = run(
+                "validator-registry",
+                "verify",
+                str(base / "validator-registry.json"),
+                "--policy",
+                str(policy),
+                "--now",
+                str(now + 7200),
+                check=False,
+            )
+            assert expired.returncode != 0
+            assert "expired" in expired.stderr
+    finally:
+        for server in servers:
+            server.close()
+
+    print("test_validator_registry: PASS")
+
+
+if __name__ == "__main__":
+    os.chdir(ROOT)
+    main()

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,6 @@
 # Power House Python SDK
 
-Version: 0.3.3
+Version: 0.3.4
 
 The default `power_house` namespace implements `.pha` v1 and Rootprint v1
 without requiring or interpreting external proof attachments.

--- a/sdk/python/power_house/__init__.py
+++ b/sdk/python/power_house/__init__.py
@@ -34,4 +34,4 @@ __all__ = [
     "verify_rootprint",
 ]
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "power-house-sdk"
-version = "0.3.3"
+version = "0.3.4"
 description = "Zero-dependency Python SDK for Power House Archive and Rootprint v1"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/bin/julian.rs
+++ b/src/bin/julian.rs
@@ -19,7 +19,8 @@ use power_house::net::{
     decode_public_key_base64, encrypt_identity_base64, load_encrypted_identity,
     load_or_derive_keypair, refresh_migration_mode_from_env, run_network, verify_signature_base64,
     AnchorEnvelope, AnchorJson, Ed25519KeySource, MembershipPolicy, MultisigPolicy, NamespaceRule,
-    NetConfig, StakePolicy, StakeRegistry, StaticPolicy,
+    NetConfig, StakePolicy, StakeRegistry, StaticPolicy, ValidatorRegistration, ValidatorRegistry,
+    VALIDATOR_REGISTRY_SCHEMA,
 };
 use power_house::provenance::{ExternalProofAttachment, PhaArtifact, Rootprint};
 use power_house::{
@@ -79,6 +80,7 @@ fn print_cli_help() {
         println!("  rollup           Settle rollup requests");
         println!("  keygen           Create an encrypted network identity");
         println!("  key-info         Inspect a network identity without exposing its secret");
+        println!("  validator-registry  Sign, assemble, and verify validator registrations");
     }
     println!();
     println!("Use 'julian <command> --help' for command details.");
@@ -234,6 +236,20 @@ fn print_key_info_help() {
 }
 
 #[cfg(feature = "net")]
+fn print_validator_registry_help() {
+    println!("Usage: julian validator-registry <create|assemble|verify> ...");
+    println!("  create --key <key> --node-id <id> --operator <name> --region <id>");
+    println!("         --p2p-address <multiaddr> --metrics-url <url>");
+    println!("         [--system-metrics-url <url>] [--chain-id <id>]");
+    println!("         [--issued-at <unix>] [--valid-until <unix>] --output <file>");
+    println!("  assemble --registration <file>... --policy <allowlist.json>");
+    println!("           [--chain-id <id>] --output <registry.json>");
+    println!("  verify <registry.json> --policy <allowlist.json> [--now <unix>] [--json]");
+    println!();
+    println!("Registrations are signed by the validator identity and do not alter consensus.");
+}
+
+#[cfg(feature = "net")]
 fn append_rollup_fault(path: &Path, ev: &power_house::rollup::RollupFaultEvidence) {
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
@@ -289,6 +305,14 @@ fn main() {
         #[cfg(feature = "net")]
         Some("key-info") => {
             cmd_key_info(args.collect());
+        }
+        #[cfg(feature = "net")]
+        Some("validator-registry") => {
+            if let Some(sub) = args.next() {
+                handle_validator_registry(&sub, args.collect());
+            } else {
+                print_validator_registry_help();
+            }
         }
         #[cfg(feature = "net")]
         Some("net") | Some("network") => {
@@ -929,6 +953,281 @@ fn cmd_key_info(args: Vec<String>) {
         println!("public_key_b64: {public_key}");
         println!("peer_id: {peer_id}");
     }
+}
+
+#[cfg(feature = "net")]
+fn handle_validator_registry(sub: &str, tail: Vec<String>) {
+    match sub {
+        "-h" | "--help" => print_validator_registry_help(),
+        "create" => cmd_validator_registry_create(tail),
+        "assemble" => cmd_validator_registry_assemble(tail),
+        "verify" => cmd_validator_registry_verify(tail),
+        _ => fatal(&format!("unknown validator-registry subcommand: {sub}")),
+    }
+}
+
+#[cfg(feature = "net")]
+fn cmd_validator_registry_create(args: Vec<String>) {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_validator_registry_help();
+        return;
+    }
+    let mut values = HashMap::new();
+    let mut iter = args.into_iter();
+    while let Some(flag) = iter.next() {
+        let value = iter
+            .next()
+            .unwrap_or_else(|| fatal(&format!("{flag} expects a value")));
+        if !matches!(
+            flag.as_str(),
+            "--key"
+                | "--node-id"
+                | "--operator"
+                | "--region"
+                | "--p2p-address"
+                | "--metrics-url"
+                | "--system-metrics-url"
+                | "--chain-id"
+                | "--issued-at"
+                | "--valid-until"
+                | "--output"
+        ) {
+            fatal(&format!("unknown argument: {flag}"));
+        }
+        if values.insert(flag.clone(), value).is_some() {
+            fatal(&format!("duplicate argument: {flag}"));
+        }
+    }
+
+    let now = unix_seconds();
+    let chain_id = parse_u64_option(values.get("--chain-id"), 177155, "--chain-id");
+    let issued_at = parse_u64_option(values.get("--issued-at"), now, "--issued-at");
+    let valid_until = parse_u64_option(
+        values.get("--valid-until"),
+        issued_at.saturating_add(365 * 24 * 60 * 60),
+        "--valid-until",
+    );
+    let key = required_option(&values, "--key");
+    let material = load_or_derive_keypair(&Ed25519KeySource::from_spec(Some(key)))
+        .unwrap_or_else(|err| fatal(&format!("failed to load validator key: {err}")));
+    let registration = ValidatorRegistration::sign(
+        chain_id,
+        required_option(&values, "--node-id").to_string(),
+        required_option(&values, "--operator").to_string(),
+        required_option(&values, "--region").to_string(),
+        required_option(&values, "--p2p-address").to_string(),
+        required_option(&values, "--metrics-url").to_string(),
+        values.get("--system-metrics-url").cloned(),
+        issued_at,
+        valid_until,
+        &material,
+    )
+    .unwrap_or_else(|err| fatal(&format!("failed to create validator registration: {err}")));
+    write_json_file(
+        Path::new(required_option(&values, "--output")),
+        &registration,
+        "validator registration",
+    );
+}
+
+#[cfg(feature = "net")]
+fn cmd_validator_registry_assemble(args: Vec<String>) {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_validator_registry_help();
+        return;
+    }
+    let mut registrations = Vec::new();
+    let mut policy = None;
+    let mut output = None;
+    let mut chain_id = 177155;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--registration" => registrations.push(PathBuf::from(
+                iter.next()
+                    .unwrap_or_else(|| fatal("--registration expects a value")),
+            )),
+            "--policy" => {
+                policy = Some(PathBuf::from(
+                    iter.next()
+                        .unwrap_or_else(|| fatal("--policy expects a value")),
+                ))
+            }
+            "--output" => {
+                output = Some(PathBuf::from(
+                    iter.next()
+                        .unwrap_or_else(|| fatal("--output expects a value")),
+                ))
+            }
+            "--chain-id" => {
+                chain_id = iter
+                    .next()
+                    .unwrap_or_else(|| fatal("--chain-id expects a value"))
+                    .parse()
+                    .unwrap_or_else(|_| fatal("invalid --chain-id"))
+            }
+            value => fatal(&format!("unknown argument: {value}")),
+        }
+    }
+    if registrations.is_empty() {
+        fatal("assemble requires at least one --registration");
+    }
+    let entries = registrations
+        .iter()
+        .map(|path| read_json_file::<ValidatorRegistration>(path, "validator registration"))
+        .collect();
+    let registry = ValidatorRegistry {
+        schema: VALIDATOR_REGISTRY_SCHEMA.to_string(),
+        chain_id,
+        registrations: entries,
+    };
+    let admitted = read_validator_policy(
+        policy
+            .as_deref()
+            .unwrap_or_else(|| fatal("assemble requires --policy")),
+    );
+    registry
+        .verify(&admitted, unix_seconds())
+        .unwrap_or_else(|err| fatal(&format!("validator registry verification failed: {err}")));
+    write_json_file(
+        output
+            .as_deref()
+            .unwrap_or_else(|| fatal("assemble requires --output")),
+        &registry,
+        "validator registry",
+    );
+}
+
+#[cfg(feature = "net")]
+fn cmd_validator_registry_verify(args: Vec<String>) {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_validator_registry_help();
+        return;
+    }
+    let mut registry_path = None;
+    let mut policy_path = None;
+    let mut now = unix_seconds();
+    let mut json = false;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--policy" => {
+                policy_path = Some(PathBuf::from(
+                    iter.next()
+                        .unwrap_or_else(|| fatal("--policy expects a value")),
+                ))
+            }
+            "--now" => {
+                now = iter
+                    .next()
+                    .unwrap_or_else(|| fatal("--now expects a value"))
+                    .parse()
+                    .unwrap_or_else(|_| fatal("invalid --now"))
+            }
+            "--json" => json = true,
+            value if registry_path.is_none() => registry_path = Some(PathBuf::from(value)),
+            value => fatal(&format!("unknown argument: {value}")),
+        }
+    }
+    let registry = read_json_file::<ValidatorRegistry>(
+        registry_path
+            .as_deref()
+            .unwrap_or_else(|| fatal("verify requires a registry path")),
+        "validator registry",
+    );
+    let admitted = read_validator_policy(
+        policy_path
+            .as_deref()
+            .unwrap_or_else(|| fatal("verify requires --policy")),
+    );
+    registry
+        .verify(&admitted, now)
+        .unwrap_or_else(|err| fatal(&format!("validator registry verification failed: {err}")));
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "chain_id": registry.chain_id,
+                "registrations": registry.registrations,
+                "schema": registry.schema,
+                "validators_verified": registry.registrations.len(),
+                "verified": true,
+            })
+        );
+    } else {
+        println!(
+            "validator registry verified: {} admitted identities on chain {}",
+            registry.registrations.len(),
+            registry.chain_id
+        );
+    }
+}
+
+#[cfg(feature = "net")]
+fn required_option<'a>(values: &'a HashMap<String, String>, key: &str) -> &'a str {
+    values
+        .get(key)
+        .map(String::as_str)
+        .unwrap_or_else(|| fatal(&format!("{key} is required")))
+}
+
+#[cfg(feature = "net")]
+fn parse_u64_option(value: Option<&String>, default: u64, name: &str) -> u64 {
+    value.map_or(default, |raw| {
+        raw.parse()
+            .unwrap_or_else(|_| fatal(&format!("invalid {name}")))
+    })
+}
+
+#[cfg(feature = "net")]
+fn unix_seconds() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(feature = "net")]
+fn read_json_file<T: serde::de::DeserializeOwned>(path: &Path, label: &str) -> T {
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|err| fatal(&format!("failed to read {label} {}: {err}", path.display())));
+    serde_json::from_str(&contents)
+        .unwrap_or_else(|err| fatal(&format!("invalid {label} {}: {err}", path.display())))
+}
+
+#[cfg(feature = "net")]
+fn write_json_file<T: serde::Serialize>(path: &Path, value: &T, label: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|err| {
+            fatal(&format!(
+                "failed to create {} directory {}: {err}",
+                label,
+                parent.display()
+            ))
+        });
+    }
+    let bytes = serde_json::to_vec_pretty(value)
+        .unwrap_or_else(|err| fatal(&format!("failed to encode {label}: {err}")));
+    fs::write(path, [bytes, b"\n".to_vec()].concat()).unwrap_or_else(|err| {
+        fatal(&format!(
+            "failed to write {label} {}: {err}",
+            path.display()
+        ))
+    });
+}
+
+#[cfg(feature = "net")]
+fn read_validator_policy(path: &Path) -> std::collections::HashSet<String> {
+    #[derive(Deserialize)]
+    struct ValidatorPolicy {
+        allowlist: Vec<String>,
+    }
+    let policy: ValidatorPolicy = read_json_file(path, "validator policy");
+    if policy.allowlist.is_empty() {
+        fatal("validator policy allowlist cannot be empty");
+    }
+    policy.allowlist.into_iter().collect()
 }
 
 #[cfg(feature = "net")]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -31,6 +31,8 @@ pub mod sign;
 pub mod stake_registry;
 /// Libp2p orchestration layer and networking runtime.
 pub mod swarm;
+/// Signed validator registration and identity validation.
+pub mod validator_registry;
 
 pub use attestation::{aggregate_attestations, Attestation, AttestationQuorum};
 pub use availability::{encode_shares, share_proof, verify_sample, ShareCommitment};
@@ -59,3 +61,7 @@ pub use sign::{
 };
 pub use stake_registry::StakeRegistry;
 pub use swarm::{run_network, NamespaceRule, NetConfig, NetworkError};
+pub use validator_registry::{
+    ValidatorRegistration, ValidatorRegistry, ValidatorRegistryError,
+    VALIDATOR_REGISTRATION_SCHEMA, VALIDATOR_REGISTRY_SCHEMA,
+};

--- a/src/net/swarm.rs
+++ b/src/net/swarm.rs
@@ -1662,6 +1662,14 @@ struct Metrics {
     native_sync_blocks_applied_total: AtomicU64,
 }
 
+#[derive(Clone)]
+struct MetricsIdentity {
+    node_id: String,
+    peer_id: String,
+    public_key_b64: String,
+    chain_id: u64,
+}
+
 impl Metrics {
     fn peer_connected(&self) {
         self.connected_peers.fetch_add(1, Ordering::Relaxed);
@@ -1715,9 +1723,11 @@ impl Metrics {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    fn render(&self) -> String {
+    fn render(&self, identity: &MetricsIdentity) -> String {
         format!(
-            "# TYPE powerhouse_connected_peers gauge\npowerhouse_connected_peers {}\n\
+            "# TYPE powerhouse_node_identity gauge\n\
+powerhouse_node_identity{{node_id=\"{}\",peer_id=\"{}\",public_key_b64=\"{}\",chain_id=\"{}\"}} 1\n\
+# TYPE powerhouse_connected_peers gauge\npowerhouse_connected_peers {}\n\
 # TYPE anchors_received_total counter\nanchors_received_total {}\n\
 # TYPE anchors_verified_total counter\nanchors_verified_total {}\n\
 # TYPE invalid_envelopes_total counter\ninvalid_envelopes_total {}\n\
@@ -1727,6 +1737,10 @@ impl Metrics {
 # TYPE native_transactions_accepted_total counter\nnative_transactions_accepted_total {}\n\
 # TYPE native_blocks_finalized_total counter\nnative_blocks_finalized_total {}\n\
 # TYPE native_sync_blocks_applied_total counter\nnative_sync_blocks_applied_total {}\n",
+            prometheus_label(&identity.node_id),
+            prometheus_label(&identity.peer_id),
+            prometheus_label(&identity.public_key_b64),
+            identity.chain_id,
             self.connected_peers.load(Ordering::Relaxed),
             self.anchors_received_total.load(Ordering::Relaxed),
             self.anchors_verified_total.load(Ordering::Relaxed),
@@ -1858,8 +1872,14 @@ pub async fn run_network(cfg: NetConfig) -> Result<(), NetworkError> {
     let metrics = cfg.metrics.clone();
     if let Some(addr) = cfg.metrics_addr {
         let metrics_clone = metrics.clone();
+        let identity = MetricsIdentity {
+            node_id: cfg.node_id.clone(),
+            peer_id: cfg.key_material.libp2p.public().to_peer_id().to_string(),
+            public_key_b64: encode_public_key_base64(&cfg.key_material.verifying),
+            chain_id: cfg.evm_chain_id,
+        };
         tokio::spawn(async move {
-            if let Err(err) = run_metrics_server(addr, metrics_clone).await {
+            if let Err(err) = run_metrics_server(addr, metrics_clone, identity).await {
                 eprintln!("metrics server error: {err}");
             }
         });
@@ -3021,13 +3041,25 @@ fn record_invalid(
     }
 }
 
-async fn run_metrics_server(addr: SocketAddr, metrics: Arc<Metrics>) -> io::Result<()> {
+fn prometheus_label(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('"', "\\\"")
+}
+
+async fn run_metrics_server(
+    addr: SocketAddr,
+    metrics: Arc<Metrics>,
+    identity: MetricsIdentity,
+) -> io::Result<()> {
     let listener = TcpListener::bind(addr).await?;
     loop {
         let (mut stream, _) = listener.accept().await?;
         let metrics = metrics.clone();
+        let identity = identity.clone();
         tokio::spawn(async move {
-            if let Err(err) = respond_with_metrics(&mut stream, metrics).await {
+            if let Err(err) = respond_with_metrics(&mut stream, metrics, identity).await {
                 eprintln!("metrics connection error: {err}");
             }
         });
@@ -3037,6 +3069,7 @@ async fn run_metrics_server(addr: SocketAddr, metrics: Arc<Metrics>) -> io::Resu
 async fn respond_with_metrics(
     stream: &mut tokio::net::TcpStream,
     metrics: Arc<Metrics>,
+    identity: MetricsIdentity,
 ) -> io::Result<()> {
     let mut buf = [0u8; 1024];
     let mut read = 0usize;
@@ -3073,7 +3106,7 @@ async fn respond_with_metrics(
         return Ok(());
     }
 
-    let body = metrics.render();
+    let body = metrics.render(&identity);
     let response = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\n\r\n{}",
         body.len(),
@@ -3565,6 +3598,21 @@ mod tests {
         metrics.peer_connected();
         metrics.peer_disconnected();
         assert_eq!(metrics.connected_peers.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn metrics_bind_live_node_identity() {
+        let metrics = Metrics::default();
+        let identity = MetricsIdentity {
+            node_id: "validator-1".to_string(),
+            peer_id: "12D3KooWExample".to_string(),
+            public_key_b64: "public/key==".to_string(),
+            chain_id: 177155,
+        };
+        let rendered = metrics.render(&identity);
+        assert!(rendered.contains(
+            "powerhouse_node_identity{node_id=\"validator-1\",peer_id=\"12D3KooWExample\",public_key_b64=\"public/key==\",chain_id=\"177155\"} 1"
+        ));
     }
 
     #[test]

--- a/src/net/validator_registry.rs
+++ b/src/net/validator_registry.rs
@@ -1,0 +1,491 @@
+#![cfg(feature = "net")]
+
+use crate::net::sign::{
+    decode_public_key_base64, encode_public_key_base64, encode_signature_base64, sign_payload,
+    verify_signature_base64, KeyMaterial,
+};
+use libp2p::{identity, multiaddr::Protocol, Multiaddr, PeerId};
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Schema identifier for a signed validator registration.
+pub const VALIDATOR_REGISTRATION_SCHEMA: &str = "power-house-validator-registration-v1";
+/// Schema identifier for an aggregate validator registry.
+pub const VALIDATOR_REGISTRY_SCHEMA: &str = "power-house-validator-registry-v1";
+
+const SIGNING_DOMAIN: &[u8] = b"MFENX-POWERHOUSE:validator-registration:v1\0";
+const MAX_REGISTRATION_LIFETIME: u64 = 400 * 24 * 60 * 60;
+const CLOCK_SKEW_SECONDS: u64 = 300;
+
+/// A validator-controlled, signed declaration of its public monitoring endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValidatorRegistration {
+    /// Registration schema.
+    pub schema: String,
+    /// EVM/native chain identifier.
+    pub chain_id: u64,
+    /// Stable human-readable node identifier.
+    pub node_id: String,
+    /// Operator name or organization.
+    pub operator: String,
+    /// Deployment region identifier.
+    pub region: String,
+    /// Libp2p peer ID derived from `public_key_b64`.
+    pub peer_id: String,
+    /// Base64 Ed25519 public key used by the validator.
+    pub public_key_b64: String,
+    /// Public or private libp2p address ending in the claimed peer ID.
+    pub p2p_address: String,
+    /// Prometheus endpoint exposing validator and identity metrics.
+    pub metrics_url: String,
+    /// Optional node-exporter endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_metrics_url: Option<String>,
+    /// Registration creation time in Unix seconds.
+    pub issued_at_unix: u64,
+    /// Registration expiration time in Unix seconds.
+    pub valid_until_unix: u64,
+    /// Base64 Ed25519 signature over the canonical registration payload.
+    pub signature_b64: String,
+}
+
+#[derive(Serialize)]
+struct CanonicalRegistration<'a> {
+    schema: &'a str,
+    chain_id: u64,
+    node_id: &'a str,
+    operator: &'a str,
+    region: &'a str,
+    peer_id: &'a str,
+    public_key_b64: &'a str,
+    p2p_address: &'a str,
+    metrics_url: &'a str,
+    system_metrics_url: &'a Option<String>,
+    issued_at_unix: u64,
+    valid_until_unix: u64,
+}
+
+impl ValidatorRegistration {
+    /// Constructs and signs a validator registration using the node identity.
+    #[allow(clippy::too_many_arguments)]
+    pub fn sign(
+        chain_id: u64,
+        node_id: String,
+        operator: String,
+        region: String,
+        p2p_address: String,
+        metrics_url: String,
+        system_metrics_url: Option<String>,
+        issued_at_unix: u64,
+        valid_until_unix: u64,
+        key_material: &KeyMaterial,
+    ) -> Result<Self, ValidatorRegistryError> {
+        let public_key_b64 = encode_public_key_base64(&key_material.verifying);
+        let peer_id = key_material.libp2p.public().to_peer_id().to_string();
+        let mut registration = Self {
+            schema: VALIDATOR_REGISTRATION_SCHEMA.to_string(),
+            chain_id,
+            node_id,
+            operator,
+            region,
+            peer_id,
+            public_key_b64,
+            p2p_address,
+            metrics_url,
+            system_metrics_url,
+            issued_at_unix,
+            valid_until_unix,
+            signature_b64: String::new(),
+        };
+        registration.validate_fields(chain_id, issued_at_unix)?;
+        registration.signature_b64 = encode_signature_base64(&sign_payload(
+            &key_material.signing,
+            &registration.payload()?,
+        ));
+        Ok(registration)
+    }
+
+    /// Verifies schema, timing, endpoint constraints, identity binding, and signature.
+    pub fn verify(
+        &self,
+        expected_chain_id: u64,
+        now_unix: u64,
+    ) -> Result<(), ValidatorRegistryError> {
+        self.validate_fields(expected_chain_id, now_unix)?;
+        let expected_peer = peer_id_from_public_key(&self.public_key_b64)?;
+        if self.peer_id != expected_peer.to_string() {
+            return Err(ValidatorRegistryError::Identity(
+                "peer_id is not derived from public_key_b64".to_string(),
+            ));
+        }
+        let address: Multiaddr = self.p2p_address.parse().map_err(|err| {
+            ValidatorRegistryError::Endpoint(format!("invalid p2p address: {err}"))
+        })?;
+        let address_peer = address.iter().last().and_then(|protocol| match protocol {
+            Protocol::P2p(peer) => Some(peer),
+            _ => None,
+        });
+        if address_peer.as_ref() != Some(&expected_peer) {
+            return Err(ValidatorRegistryError::Identity(
+                "p2p_address does not end in the registered peer_id".to_string(),
+            ));
+        }
+        let p2p_host = address
+            .iter()
+            .find_map(|protocol| match protocol {
+                Protocol::Ip4(value) => Some(value.to_string()),
+                Protocol::Ip6(value) => Some(value.to_string()),
+                Protocol::Dns(value) | Protocol::Dns4(value) | Protocol::Dns6(value) => {
+                    Some(value.to_string())
+                }
+                _ => None,
+            })
+            .ok_or_else(|| {
+                ValidatorRegistryError::Endpoint(
+                    "p2p_address must contain an IP or DNS host".to_string(),
+                )
+            })?;
+        require_matching_host("metrics_url", &self.metrics_url, &p2p_host)?;
+        if let Some(url) = &self.system_metrics_url {
+            require_matching_host("system_metrics_url", url, &p2p_host)?;
+        }
+        verify_signature_base64(&self.public_key_b64, &self.payload()?, &self.signature_b64)
+            .map_err(|err| ValidatorRegistryError::Signature(err.to_string()))
+    }
+
+    fn payload(&self) -> Result<Vec<u8>, ValidatorRegistryError> {
+        let canonical = CanonicalRegistration {
+            schema: &self.schema,
+            chain_id: self.chain_id,
+            node_id: &self.node_id,
+            operator: &self.operator,
+            region: &self.region,
+            peer_id: &self.peer_id,
+            public_key_b64: &self.public_key_b64,
+            p2p_address: &self.p2p_address,
+            metrics_url: &self.metrics_url,
+            system_metrics_url: &self.system_metrics_url,
+            issued_at_unix: self.issued_at_unix,
+            valid_until_unix: self.valid_until_unix,
+        };
+        let mut payload = SIGNING_DOMAIN.to_vec();
+        payload.extend(
+            serde_json::to_vec(&canonical)
+                .map_err(|err| ValidatorRegistryError::Encoding(err.to_string()))?,
+        );
+        Ok(payload)
+    }
+
+    fn validate_fields(
+        &self,
+        expected_chain_id: u64,
+        now_unix: u64,
+    ) -> Result<(), ValidatorRegistryError> {
+        if self.schema != VALIDATOR_REGISTRATION_SCHEMA {
+            return Err(ValidatorRegistryError::Schema(self.schema.clone()));
+        }
+        if self.chain_id != expected_chain_id {
+            return Err(ValidatorRegistryError::ChainId {
+                expected: expected_chain_id,
+                actual: self.chain_id,
+            });
+        }
+        validate_identifier("node_id", &self.node_id)?;
+        validate_identifier("region", &self.region)?;
+        if self.operator.trim().is_empty() || self.operator.len() > 128 {
+            return Err(ValidatorRegistryError::Field(
+                "operator must contain 1 to 128 characters".to_string(),
+            ));
+        }
+        if self.issued_at_unix > now_unix.saturating_add(CLOCK_SKEW_SECONDS) {
+            return Err(ValidatorRegistryError::Timing(
+                "registration issue time is in the future".to_string(),
+            ));
+        }
+        if self.valid_until_unix <= now_unix {
+            return Err(ValidatorRegistryError::Timing(
+                "registration has expired".to_string(),
+            ));
+        }
+        let lifetime = self
+            .valid_until_unix
+            .checked_sub(self.issued_at_unix)
+            .ok_or_else(|| {
+                ValidatorRegistryError::Timing(
+                    "registration expiration precedes issue time".to_string(),
+                )
+            })?;
+        if lifetime == 0 || lifetime > MAX_REGISTRATION_LIFETIME {
+            return Err(ValidatorRegistryError::Timing(format!(
+                "registration lifetime must be between 1 and {MAX_REGISTRATION_LIFETIME} seconds"
+            )));
+        }
+        validate_metrics_url("metrics_url", &self.metrics_url)?;
+        if let Some(url) = &self.system_metrics_url {
+            validate_metrics_url("system_metrics_url", url)?;
+        }
+        decode_public_key_base64(&self.public_key_b64)
+            .map_err(|err| ValidatorRegistryError::Identity(err.to_string()))?;
+        Ok(())
+    }
+}
+
+/// A set of individually signed validator registrations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValidatorRegistry {
+    /// Registry schema.
+    pub schema: String,
+    /// Chain identifier shared by every registration.
+    pub chain_id: u64,
+    /// Signed validator records.
+    pub registrations: Vec<ValidatorRegistration>,
+}
+
+impl ValidatorRegistry {
+    /// Verifies all records and requires every identity to be admitted by policy.
+    pub fn verify(
+        &self,
+        admitted_public_keys: &HashSet<String>,
+        now_unix: u64,
+    ) -> Result<(), ValidatorRegistryError> {
+        if self.schema != VALIDATOR_REGISTRY_SCHEMA {
+            return Err(ValidatorRegistryError::Schema(self.schema.clone()));
+        }
+        if self.chain_id == 0 {
+            return Err(ValidatorRegistryError::Field(
+                "chain_id must be non-zero".to_string(),
+            ));
+        }
+        if self.registrations.is_empty() {
+            return Err(ValidatorRegistryError::Field(
+                "registry must contain at least one registration".to_string(),
+            ));
+        }
+
+        let mut node_ids = HashSet::new();
+        let mut peer_ids = HashSet::new();
+        let mut public_keys = HashSet::new();
+        let mut metrics_urls = HashSet::new();
+        for registration in &self.registrations {
+            registration.verify(self.chain_id, now_unix)?;
+            if !admitted_public_keys.contains(&registration.public_key_b64) {
+                return Err(ValidatorRegistryError::Admission(
+                    registration.node_id.clone(),
+                ));
+            }
+            require_unique(&mut node_ids, &registration.node_id, "node_id")?;
+            require_unique(&mut peer_ids, &registration.peer_id, "peer_id")?;
+            require_unique(
+                &mut public_keys,
+                &registration.public_key_b64,
+                "public_key_b64",
+            )?;
+            require_unique(&mut metrics_urls, &registration.metrics_url, "metrics_url")?;
+        }
+        Ok(())
+    }
+}
+
+fn peer_id_from_public_key(public_key_b64: &str) -> Result<PeerId, ValidatorRegistryError> {
+    let verifying = decode_public_key_base64(public_key_b64)
+        .map_err(|err| ValidatorRegistryError::Identity(err.to_string()))?;
+    let public = identity::ed25519::PublicKey::try_from_bytes(&verifying.to_bytes())
+        .map_err(|err| ValidatorRegistryError::Identity(err.to_string()))?;
+    Ok(identity::PublicKey::from(public).to_peer_id())
+}
+
+fn validate_identifier(field: &str, value: &str) -> Result<(), ValidatorRegistryError> {
+    let valid = !value.is_empty()
+        && value.len() <= 64
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"-._".contains(&byte)
+        })
+        && value.as_bytes()[0].is_ascii_alphanumeric()
+        && value.as_bytes()[value.len() - 1].is_ascii_alphanumeric();
+    if valid {
+        Ok(())
+    } else {
+        Err(ValidatorRegistryError::Field(format!(
+            "{field} must be 1 to 64 lowercase alphanumeric, dash, dot, or underscore characters"
+        )))
+    }
+}
+
+fn validate_metrics_url(field: &str, value: &str) -> Result<(), ValidatorRegistryError> {
+    let url = Url::parse(value).map_err(|err| ValidatorRegistryError::Endpoint(err.to_string()))?;
+    if !matches!(url.scheme(), "http" | "https")
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.host_str().is_none()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.path() != "/metrics"
+        || url.port_or_known_default().is_none()
+    {
+        return Err(ValidatorRegistryError::Endpoint(format!(
+            "{field} must be an http(s) URL ending exactly in /metrics without credentials, query, or fragment"
+        )));
+    }
+    Ok(())
+}
+
+fn require_matching_host(
+    field: &str,
+    value: &str,
+    p2p_host: &str,
+) -> Result<(), ValidatorRegistryError> {
+    let url = Url::parse(value).map_err(|err| ValidatorRegistryError::Endpoint(err.to_string()))?;
+    if !url
+        .host_str()
+        .is_some_and(|host| host.eq_ignore_ascii_case(p2p_host))
+    {
+        return Err(ValidatorRegistryError::Endpoint(format!(
+            "{field} host must match the p2p_address host"
+        )));
+    }
+    Ok(())
+}
+
+fn require_unique(
+    seen: &mut HashSet<String>,
+    value: &str,
+    field: &str,
+) -> Result<(), ValidatorRegistryError> {
+    if seen.insert(value.to_string()) {
+        Ok(())
+    } else {
+        Err(ValidatorRegistryError::Duplicate(field.to_string()))
+    }
+}
+
+/// Validator registry validation failure.
+#[derive(Debug, thiserror::Error)]
+pub enum ValidatorRegistryError {
+    /// Unsupported schema.
+    #[error("unsupported validator registry schema: {0}")]
+    Schema(String),
+    /// Chain mismatch.
+    #[error("validator registration chain mismatch: expected {expected}, got {actual}")]
+    ChainId {
+        /// Expected chain ID.
+        expected: u64,
+        /// Registration chain ID.
+        actual: u64,
+    },
+    /// Invalid field.
+    #[error("invalid validator registration field: {0}")]
+    Field(String),
+    /// Invalid timing.
+    #[error("invalid validator registration timing: {0}")]
+    Timing(String),
+    /// Invalid endpoint.
+    #[error("invalid validator endpoint: {0}")]
+    Endpoint(String),
+    /// Identity binding failed.
+    #[error("validator identity mismatch: {0}")]
+    Identity(String),
+    /// Signature failed.
+    #[error("validator registration signature failed: {0}")]
+    Signature(String),
+    /// Canonical encoding failed.
+    #[error("validator registration encoding failed: {0}")]
+    Encoding(String),
+    /// Identity is not admitted by the consensus policy.
+    #[error("validator {0} is not admitted by the validator policy")]
+    Admission(String),
+    /// A supposedly unique field was repeated.
+    #[error("duplicate validator registration {0}")]
+    Duplicate(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::net::{load_or_derive_keypair, Ed25519KeySource};
+
+    fn registration(seed: &str, node_id: &str) -> ValidatorRegistration {
+        let keys = load_or_derive_keypair(&Ed25519KeySource::Seed(seed.to_string())).expect("keys");
+        let peer_id = keys.libp2p.public().to_peer_id();
+        ValidatorRegistration::sign(
+            177155,
+            node_id.to_string(),
+            "MFENX LLC".to_string(),
+            "sfo3".to_string(),
+            format!("/ip4/127.0.0.1/tcp/7001/p2p/{peer_id}"),
+            "http://127.0.0.1:9100/metrics".to_string(),
+            Some("http://127.0.0.1:9101/metrics".to_string()),
+            1_000,
+            2_000,
+            &keys,
+        )
+        .expect("registration")
+    }
+
+    #[test]
+    fn signed_registration_binds_public_key_peer_id_and_address() {
+        registration("validator-a", "validator-a")
+            .verify(177155, 1_500)
+            .expect("valid registration");
+    }
+
+    #[test]
+    fn identity_and_signed_fields_reject_mutation() {
+        let mut item = registration("validator-a", "validator-a");
+        item.region = "nyc3".to_string();
+        assert!(matches!(
+            item.verify(177155, 1_500),
+            Err(ValidatorRegistryError::Signature(_))
+        ));
+
+        let mut item = registration("validator-a", "validator-a");
+        item.peer_id = registration("validator-b", "validator-b").peer_id;
+        assert!(matches!(
+            item.verify(177155, 1_500),
+            Err(ValidatorRegistryError::Identity(_))
+        ));
+    }
+
+    #[test]
+    fn expiration_and_endpoint_constraints_are_enforced() {
+        let item = registration("validator-a", "validator-a");
+        assert!(matches!(
+            item.verify(177155, 2_000),
+            Err(ValidatorRegistryError::Timing(_))
+        ));
+
+        let mut item = registration("validator-a", "validator-a");
+        item.metrics_url = "file:///etc/passwd".to_string();
+        assert!(matches!(
+            item.verify(177155, 1_500),
+            Err(ValidatorRegistryError::Endpoint(_))
+        ));
+    }
+
+    #[test]
+    fn registry_requires_admission_and_unique_identities() {
+        let item = registration("validator-a", "validator-a");
+        let registry = ValidatorRegistry {
+            schema: VALIDATOR_REGISTRY_SCHEMA.to_string(),
+            chain_id: 177155,
+            registrations: vec![item.clone()],
+        };
+        let admitted = HashSet::from([item.public_key_b64.clone()]);
+        registry.verify(&admitted, 1_500).expect("admitted");
+        assert!(matches!(
+            registry.verify(&HashSet::new(), 1_500),
+            Err(ValidatorRegistryError::Admission(_))
+        ));
+
+        let duplicate = ValidatorRegistry {
+            registrations: vec![item.clone(), item],
+            ..registry
+        };
+        assert!(matches!(
+            duplicate.verify(&admitted, 1_500),
+            Err(ValidatorRegistryError::Duplicate(_))
+        ));
+    }
+}


### PR DESCRIPTION
## What changed

- adds signed validator registrations bound to Ed25519 identity and derived libp2p peer IDs
- verifies policy admission, chain identity, endpoints, expiration, uniqueness, and live node identity metrics
- replaces hardcoded monitoring targets and validator totals with atomic dynamic discovery
- adds health reconciliation, stale-state handling, deployment integration, documentation, and v0.3.4 release metadata

## Safety boundary

Monitoring enrollment remains separate from persisted consensus membership and quorum transitions. Invalid registries fail closed and preserve last-known-good discovery targets.

## Validation

- cargo fmt --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-targets --locked
- cargo test --all-targets --features net --locked
- all-feature rustdoc with warnings denied and 9/9 README API links
- signed registry mutation, identity mismatch, expiration, admission, stale-state, and dynamic-count tests
- deployment bundle, CLI, release consistency, Observatory, Python, and shell contract tests
- cargo package --locked from a clean tree