### PR TITLE
Release v0.3.5 monitoring discovery hotfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "power_house"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "power_house"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["MFENX LLC"]
 description = "Deterministic proofs, portable .pha provenance, Rootprint graphs, and optional quorum networking."

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN cargo build --release --locked --features net --bin julian
 
 FROM debian:bookworm-slim
-ARG POWER_HOUSE_VERSION=0.3.4
+ARG POWER_HOUSE_VERSION=0.3.5
 LABEL org.opencontainers.image.title="Power House" \
   org.opencontainers.image.version="${POWER_HOUSE_VERSION}" \
   org.opencontainers.image.source="https://github.com/JROChub/power_house"

--- a/JULIAN_PROTOCOL.md
+++ b/JULIAN_PROTOCOL.md
@@ -1,5 +1,5 @@
 MFENX Power-House Network: The JULIAN Protocol Network
-Version 0.3.4 - June 2026
+Version 0.3.5 - June 2026
 
 
 # JULIAN Protocol: Proof-Transparent Consensus via Folding-Derived Anchors

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ combines structured sum-check proofs, portable `.pha` artifacts, Rootprint
 proof-history graphs, commitment-bound sparse workloads, transcript anchoring,
 and an optional quorum network.
 
-Current release: **v0.3.4**
+Current release: **v0.3.5**
 
 The primary workflow is **Power House + Rootprint**:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v0.3.5 - 2026-06-13
+
+### Monitoring Hotfix
+- Corrected Prometheus file-discovery permissions from private health-state
+  mode to world-readable public target metadata mode.
+- Retained `0640` protection for detailed validator health state.
+- Added regression assertions for validator discovery, system discovery, and
+  private state-file permissions.
+- Verified all three production validator and system targets are dynamically
+  discovered and reporting `up`.
+
 ## v0.3.4 - 2026-06-13
 
 ### Signed Validator Registry

--- a/configs/network.json
+++ b/configs/network.json
@@ -7,7 +7,7 @@
     "name": "JULIAN",
     "symbol": "JULIAN"
   },
-  "release": "0.3.4",
+  "release": "0.3.5",
   "benchmarkReport": "benchmarks/v0.3.2/rpc-report.json",
   "rpc": {
     "canonicalUrl": "https://rpc.mfenx.com",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   node:
-    image: ghcr.io/jrochub/power_house:0.3.4
+    image: ghcr.io/jrochub/power_house:0.3.5
     build: .
     command:
       [

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Power House Documentation
 
-This index is the authoritative map for Power House v0.3.4 documentation.
+This index is the authoritative map for Power House v0.3.5 documentation.
 
 ## Start Here
 

--- a/docs/committed_workload.md
+++ b/docs/committed_workload.md
@@ -1,6 +1,6 @@
 # Externally Committed Sparse Workload
 
-Status: active format guide for Power House v0.3.4.
+Status: active format guide for Power House v0.3.5.
 
 Power-House can now bind a sum-check certificate to a separately supplied
 sparse polynomial file.

--- a/docs/hyperscale_proof.md
+++ b/docs/hyperscale_proof.md
@@ -1,6 +1,6 @@
 # Hyperscale Seeded-Affine Proof
 
-Status: active proof profile for Power House v0.3.4.
+Status: active proof profile for Power House v0.3.5.
 
 `examples/hyperscale_affine.rs` demonstrates a non-constant sum-check
 certificate over domains far larger than sextillion scale.

--- a/docs/incident_response.md
+++ b/docs/incident_response.md
@@ -1,6 +1,6 @@
 # MFENX Incident Response
 
-Release scope: Power House v0.3.4.
+Release scope: Power House v0.3.5.
 
 ## Severity
 

--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -1,6 +1,6 @@
 # MFENX Network Load Testing
 
-Release scope: Power House v0.3.4.
+Release scope: Power House v0.3.5.
 
 Run read-only public RPC tests before transaction tests. Never direct an
 unbounded load generator at production.

--- a/docs/network_roadmap.md
+++ b/docs/network_roadmap.md
@@ -1,6 +1,6 @@
 # MFENX Stable Public Network Roadmap
 
-Release scope: Power House v0.3.4.
+Release scope: Power House v0.3.5.
 
 The target is a public network that fails predictably, recovers automatically,
 and exposes enough evidence for operators and users to determine its state.

--- a/docs/node_operator.md
+++ b/docs/node_operator.md
@@ -1,6 +1,6 @@
 # MFENX Node Operator Guide
 
-Release scope: Power House v0.3.4.
+Release scope: Power House v0.3.5.
 
 This guide starts a public observer. Validator admission additionally requires
 a consensus identity approved by the active membership policy.
@@ -19,14 +19,14 @@ unless a firewall and authenticated reverse proxy explicitly protect them.
 ## Install
 
 ```bash
-cargo install power_house --version 0.3.4 --features net --locked
+cargo install power_house --version 0.3.5 --features net --locked
 julian --version
 ```
 
 Or use the release container:
 
 ```bash
-docker pull ghcr.io/jrochub/power_house:0.3.4
+docker pull ghcr.io/jrochub/power_house:0.3.5
 ```
 
 ## Create An Identity

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,9 +1,9 @@
 # Power-House Operations Guide
 
-Release scope: Power House v0.3.4.
+Release scope: Power House v0.3.5.
 
 This guide documents the retained boot-node, JULIAN network, and blob-service
-operations in v0.3.4. For the current three-validator native RPC topology and
+operations in v0.3.5. For the current three-validator native RPC topology and
 public HTTPS edge, use
 [Production RPC Deployment](production_rpc_deployment.md). Commands here
 assume explicit operator control so each change remains auditable.

--- a/docs/orbital_observatory.md
+++ b/docs/orbital_observatory.md
@@ -1,6 +1,6 @@
 # MFENX Orbital Observatory
 
-Release surface: Power House v0.3.4.
+Release surface: Power House v0.3.5.
 
 `mfenx.com` presents Power House as an interactive planetary proof
 observatory. It combines live celestial telemetry, world time, published proof

--- a/docs/pha_spec.md
+++ b/docs/pha_spec.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Normative for Power House v0.3.4.
+Normative for Power House v0.3.5.
 
 This document defines the portable Power House Archive v1 JSON format. The
 schema identifier is:

--- a/docs/prior_art_review.md
+++ b/docs/prior_art_review.md
@@ -1,6 +1,6 @@
 # Prior-Art Review
 
-Status: active technical review for Power House v0.3.4.
+Status: active technical review for Power House v0.3.5.
 
 ## Question Under Review
 

--- a/docs/production_rpc_deployment.md
+++ b/docs/production_rpc_deployment.md
@@ -1,6 +1,6 @@
 # LAX MFENX RPC Production Deployment
 
-Release scope: Power House v0.3.4.
+Release scope: Power House v0.3.5.
 
 The retired VPS hosts should not be restored. Replace them with a reproducible
 three-validator deployment whose membership, keys, genesis balances, service
@@ -151,7 +151,7 @@ restarts one validator at a time, waits for RPC health, verifies
 Allow validator-tag traffic to TCP `9090`, `9100`, and `9101`, then run:
 
 ```bash
-POWER_HOUSE_RELEASE=0.3.4 \
+POWER_HOUSE_RELEASE=0.3.5 \
 SSH_OPTS="-F /dev/null -o StrictHostKeyChecking=accept-new" \
 scripts/deploy_monitoring_stack.sh \
   root@<validator-1-ipv4> \

--- a/docs/provenance_security.md
+++ b/docs/provenance_security.md
@@ -1,6 +1,6 @@
 # Provenance Security Model
 
-Status: active security statement for Power House v0.3.4.
+Status: active security statement for Power House v0.3.5.
 
 This document defines the integrity boundary for Power House Archive (`.pha`)
 v1, Rootprint v1, and optional external proof attachments.

--- a/docs/research_protocol.md
+++ b/docs/research_protocol.md
@@ -1,6 +1,6 @@
 # Research Protocol
 
-Status: active research and evidence protocol for Power House v0.3.4.
+Status: active research and evidence protocol for Power House v0.3.5.
 
 This document turns Power-House development into a falsifiable research
 program. Scale demonstrations remain useful, but exponent size alone is not a

--- a/docs/rootprint.md
+++ b/docs/rootprint.md
@@ -1,6 +1,6 @@
 # Rootprint v1
 
-Status: normative for Power House v0.3.4.
+Status: normative for Power House v0.3.5.
 
 Rootprint is the primary Power House provenance workflow. It is a deterministic
 directed acyclic graph whose nodes carry `.pha` artifacts and whose edges record

--- a/docs/rpc_operations.md
+++ b/docs/rpc_operations.md
@@ -1,6 +1,6 @@
 # Power-House RPC Operations
 
-Release scope: Power House v0.3.4.
+Release scope: Power House v0.3.5.
 
 Power-House exposes a native-transfer JSON-RPC lane whose blocks and account
 state are finalized by the configured validator quorum. Chain ID `177155` is

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,6 +1,6 @@
 # SDKs
 
-Power House v0.3.4 ships matching Rust and zero-dependency Python interfaces
+Power House v0.3.5 ships matching Rust and zero-dependency Python interfaces
 for `.pha` and Rootprint v1.
 
 ## Rust

--- a/docs/security_model.md
+++ b/docs/security_model.md
@@ -1,6 +1,6 @@
 # Sparse Certificate Security Model
 
-Status: active security statement for Power House v0.3.4 sparse formats.
+Status: active security statement for Power House v0.3.5 sparse formats.
 
 This document defines what `PHSPv1`, `PHSMv1`, and `PHCPv1` establish and what
 they do not establish.

--- a/docs/sextillion_proof.md
+++ b/docs/sextillion_proof.md
@@ -1,6 +1,6 @@
 # Sextillion-Scale Verification Certificate
 
-Status: active proof profile for Power House v0.3.4.
+Status: active proof profile for Power House v0.3.5.
 
 Power-House can verify a sum-check claim over a domain larger than one
 sextillion points without enumerating the domain.

--- a/docs/sparse_record.md
+++ b/docs/sparse_record.md
@@ -1,6 +1,6 @@
 # Public Sparse Computation Certificate
 
-Status: active format guide for Power House v0.3.4.
+Status: active format guide for Power House v0.3.5.
 
 Power-House now includes an event-driven sum-check prover for a public seeded
 sparse multilinear polynomial:

--- a/docs/testnet_mainnet.md
+++ b/docs/testnet_mainnet.md
@@ -1,6 +1,6 @@
 # MFENX Testnet To Mainnet Process
 
-Release scope: Power House v0.3.4.
+Release scope: Power House v0.3.5.
 
 Chain metadata currently identifies chain `177155` as active. Future mainnet
 launches or incompatible resets must use this process rather than silently

--- a/docs/validator_registry.md
+++ b/docs/validator_registry.md
@@ -1,6 +1,6 @@
 # Signed Validator Registry
 
-Release scope: Power House v0.3.4.
+Release scope: Power House v0.3.5.
 
 The validator registry replaces hardcoded monitoring totals with signed,
 policy-admitted, live identity checks. It controls monitoring discovery and

--- a/docs/verification_guide.md
+++ b/docs/verification_guide.md
@@ -1,6 +1,6 @@
 # Verification Guide
 
-This guide reproduces the Power House v0.3.4 provenance and proof workflows.
+This guide reproduces the Power House v0.3.5 provenance and proof workflows.
 
 ## Requirements
 

--- a/infra/monitoring/validator_registry.py
+++ b/infra/monitoring/validator_registry.py
@@ -264,8 +264,8 @@ def reconcile(args: argparse.Namespace) -> dict:
         "validators": validators,
         "error": None,
     }
-    atomic_json(args.powerhouse_discovery, powerhouse_discovery)
-    atomic_json(args.node_discovery, node_discovery)
+    atomic_json(args.powerhouse_discovery, powerhouse_discovery, mode=0o644)
+    atomic_json(args.node_discovery, node_discovery, mode=0o644)
     atomic_json(args.state, state)
     return state
 

--- a/publicpower/app.css
+++ b/publicpower/app.css
@@ -1856,7 +1856,7 @@ body.proof-verified .proof-event b {
   }
 }
 
-/* v0.3.4 Observatory command surface */
+/* v0.3.5 Observatory command surface */
 :root {
   --mode-color: #45ddd2;
   --top: 68px;

--- a/publicpower/index.html
+++ b/publicpower/index.html
@@ -123,7 +123,7 @@
       </button>
 
       <div class="rail-status" aria-label="Release state">
-        <div><span>RELEASE</span><b>v0.3.4</b></div>
+        <div><span>RELEASE</span><b>v0.3.5</b></div>
         <div><span>CORE</span><b>DETERMINISTIC</b></div>
       </div>
     </aside>
@@ -294,7 +294,7 @@
       <div class="evaluation-links">
         <a href="https://github.com/JROChub/power_house/blob/main/docs/verification_guide.md">REPRODUCE</a>
         <a href="https://github.com/JROChub/power_house/blob/main/docs/security_model.md">SECURITY MODEL</a>
-        <a href="https://crates.io/crates/power_house">CRATE v0.3.4</a>
+        <a href="https://crates.io/crates/power_house">CRATE v0.3.5</a>
       </div>
     </aside>
 
@@ -335,7 +335,7 @@
         <div><span>CLAIM</span><b id="claim-value">WAITING</b></div>
         <div><span>DIGEST</span><b id="digest-value">PENDING</b></div>
         <div><span>MODE</span><b id="mode-value">ROOTPRINT</b></div>
-        <div><span>RELEASE</span><b>v0.3.4</b></div>
+        <div><span>RELEASE</span><b>v0.3.5</b></div>
       </div>
     </section>
 

--- a/publicpower/status.html
+++ b/publicpower/status.html
@@ -17,7 +17,7 @@
       <img src="assets/powerhouse-logo.png" alt="">
       <span><b>MFENX</b><small>POWER HOUSE NETWORK CONTROL</small></span>
     </a>
-    <div class="release"><span>RELEASE</span><b>v0.3.4</b></div>
+    <div class="release"><span>RELEASE</span><b>v0.3.5</b></div>
   </header>
 
   <main>

--- a/scripts/test_validator_registry.py
+++ b/scripts/test_validator_registry.py
@@ -6,6 +6,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import os
 from pathlib import Path
+import stat
 import subprocess
 import sys
 import tempfile
@@ -192,6 +193,9 @@ def main() -> None:
             assert all(item["identity_verified"] for item in health["validators"])
             assert len(json.loads(powerhouse_discovery.read_text())) == 3
             assert len(json.loads(node_discovery.read_text())) == 3
+            assert stat.S_IMODE(powerhouse_discovery.stat().st_mode) == 0o644
+            assert stat.S_IMODE(node_discovery.stat().st_mode) == 0o644
+            assert stat.S_IMODE(state.stat().st_mode) == 0o640
 
             servers[1].body = metric_body(
                 {**nodes[1], "peer_id": nodes[0]["peer_id"]}

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,6 @@
 # Power House Python SDK
 
-Version: 0.3.4
+Version: 0.3.5
 
 The default `power_house` namespace implements `.pha` v1 and Rootprint v1
 without requiring or interpreting external proof attachments.

--- a/sdk/python/power_house/__init__.py
+++ b/sdk/python/power_house/__init__.py
@@ -34,4 +34,4 @@ __all__ = [
     "verify_rootprint",
 ]
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "power-house-sdk"
-version = "0.3.4"
+version = "0.3.5"
 description = "Zero-dependency Python SDK for Power House Archive and Rootprint v1"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Fix

Prometheus file discovery was generated with the private health-state mode (`0640 root:root`), preventing the Prometheus service account from reading dynamic validator targets.

This hotfix:

- writes public target discovery files as `0644`
- retains private validator health state as `0640`
- adds regression assertions for all three output modes
- advances public release metadata to v0.3.5

## Production verification

After applying the corrected reconciler, Prometheus dynamically discovered all three validator targets and all three system targets, with every target reporting `up`.

## Validation

- registry integration and permission regression tests
- dynamic status contract tests
- release consistency and rustdoc link gates
- clean-tree cargo package --locked
- production target discovery audit