### PR TITLE
Fix responsive globe viewport and proof explorer

### DIFF
--- a/publicpower/app.css
+++ b/publicpower/app.css
@@ -14,6 +14,11 @@
   --coral: #ff7167;
   --top: 64px;
   --dock: 176px;
+  --scene-left: 236px;
+  --proof-stack: 0px;
+  --explorer-closed: 42px;
+  --explorer-open: 238px;
+  --scene-bottom: calc(var(--dock) + var(--proof-stack));
   font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
   background: var(--ink);
   color: var(--paper);
@@ -82,7 +87,7 @@ svg {
   position: relative;
   width: 100%;
   height: 100dvh;
-  min-height: 620px;
+  min-height: 0;
   overflow: hidden;
   isolation: isolate;
   background: #010405 url("assets/proof-lattice.webp") center / cover no-repeat;
@@ -90,12 +95,13 @@ svg {
 
 #orbital-canvas {
   position: absolute;
-  inset: 0;
+  inset: var(--top) 0 auto var(--scene-left);
   z-index: 1;
-  width: 100%;
-  height: 100%;
+  width: calc(100% - var(--scene-left));
+  height: calc(100% - var(--top) - var(--scene-bottom));
   cursor: grab;
   touch-action: none;
+  transition: height 260ms ease, left 260ms ease, width 260ms ease;
 }
 
 #orbital-canvas:active {
@@ -112,7 +118,7 @@ svg {
 
 .scan-grid {
   position: absolute;
-  inset: var(--top) 0 var(--dock);
+  inset: var(--top) 0 var(--scene-bottom) var(--scene-left);
   z-index: 2;
   pointer-events: none;
   opacity: 0.2;
@@ -125,7 +131,7 @@ svg {
 
 .edge-vignette {
   position: absolute;
-  inset: var(--top) 0 var(--dock);
+  inset: var(--top) 0 var(--scene-bottom) var(--scene-left);
   z-index: 3;
   pointer-events: none;
   box-shadow:
@@ -1620,7 +1626,7 @@ body.proof-verified .proof-event b {
   }
 
   #app {
-    min-height: 560px;
+    min-height: 0;
   }
 
   .topbar {
@@ -1871,7 +1877,7 @@ body.proof-verified .proof-event b {
   z-index: 34;
   display: grid;
   grid-template-rows: 42px minmax(0, 1fr);
-  height: 238px;
+  height: var(--explorer-closed);
   overflow: hidden;
   color: var(--paper);
   border-top: 1px solid rgba(69, 221, 210, 0.34);
@@ -1882,13 +1888,25 @@ body.proof-verified .proof-event b {
   opacity: 0;
   transform: translateY(18px);
   pointer-events: none;
-  transition: opacity 260ms ease, transform 260ms ease;
+  transition: height 260ms ease, opacity 260ms ease, transform 260ms ease;
 }
 
 body.luminous-mode .luminous-explorer {
   opacity: 1;
   transform: translateY(0);
   pointer-events: auto;
+}
+
+body.luminous-mode {
+  --scene-bottom: calc(var(--dock) + var(--proof-stack) + var(--explorer-closed));
+}
+
+body.luminous-mode.luminous-expanded {
+  --scene-bottom: calc(var(--dock) + var(--proof-stack) + var(--explorer-open));
+}
+
+body.luminous-expanded .luminous-explorer {
+  height: var(--explorer-open);
 }
 
 .luminous-heading {
@@ -1900,6 +1918,39 @@ body.luminous-mode .luminous-explorer {
   padding: 0 18px;
   border-bottom: 1px solid var(--line);
   background: rgba(0, 5, 6, 0.72);
+}
+
+.luminous-heading dl {
+  flex: 1;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+.luminous-toggle {
+  display: grid;
+  flex: none;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  color: var(--cyan);
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.02);
+  cursor: pointer;
+  place-items: center;
+}
+
+.luminous-toggle:hover {
+  color: var(--paper);
+  border-color: rgba(69, 221, 210, 0.5);
+}
+
+.luminous-toggle svg {
+  transform: rotate(-90deg);
+  transition: transform 220ms ease;
+}
+
+body.luminous-expanded .luminous-toggle svg {
+  transform: rotate(90deg);
 }
 
 .luminous-heading > div {
@@ -2192,7 +2243,6 @@ body.luminous-mode .luminous-explorer {
   .luminous-explorer {
     bottom: calc(var(--dock) + 61px);
     left: 0;
-    height: 220px;
   }
 
   .luminous-heading {
@@ -2221,7 +2271,6 @@ body.luminous-mode .luminous-explorer {
 @media (max-width: 600px) {
   .luminous-explorer {
     grid-template-rows: 36px minmax(0, 1fr);
-    height: 232px;
   }
 
   .luminous-heading > div {
@@ -2229,7 +2278,7 @@ body.luminous-mode .luminous-explorer {
   }
 
   .luminous-heading dl {
-    width: 100%;
+    width: auto;
   }
 
   .luminous-heading dl div {
@@ -2310,8 +2359,8 @@ body.luminous-mode .luminous-explorer {
 }
 
 @media (max-height: 720px) and (min-width: 901px) {
-  .luminous-explorer {
-    height: 196px;
+  :root {
+    --explorer-open: 196px;
   }
 }
 
@@ -3141,8 +3190,7 @@ body[data-network="outage"] .network-ribbon-state i {
   }
 
   #sound-toggle,
-  #motion-toggle,
-  #zoom-out {
+  #motion-toggle {
     display: none;
   }
 
@@ -3187,5 +3235,27 @@ body[data-network="outage"] .network-ribbon-state i {
 
   .telemetry > div:not(.status-seal) {
     padding: 0 7px;
+  }
+}
+
+/* Keep the orbital scene inside the unobstructed instrument viewport. */
+@media (max-width: 1180px) {
+  :root {
+    --scene-left: 220px;
+  }
+}
+
+@media (max-width: 900px) {
+  :root {
+    --scene-left: 0px;
+    --proof-stack: 61px;
+    --explorer-open: 220px;
+  }
+}
+
+@media (max-width: 600px) {
+  :root {
+    --explorer-closed: 36px;
+    --explorer-open: 232px;
   }
 }

--- a/publicpower/app.js
+++ b/publicpower/app.js
@@ -290,6 +290,7 @@ const el = Object.fromEntries(
     "monument-index",
     "network-console",
     "luminous-explorer",
+    "luminous-toggle",
     "luminous-core-state",
     "luminous-sidecar-state",
     "luminous-packet-count",
@@ -323,6 +324,7 @@ const state = {
   luminousGraph: null,
   luminousSidecar: null,
   luminousBranch: null,
+  luminousExpanded: false,
 };
 
 const formatterCache = new Map();
@@ -356,6 +358,8 @@ let animationFrame;
 let audioContext;
 let latestSolar = null;
 let autoProofTimer = 0;
+let sceneResizeFrame = 0;
+let sceneResizeObserver;
 const networkLinks = [];
 const networkCityIndexes = [0, 3, 7];
 
@@ -1024,9 +1028,9 @@ async function createEarth() {
 }
 
 function createOrbitTrack(name, index) {
-  const radius = [1.78, 1.98, 2.17, 2.36][index];
-  const tiltX = [0.4, 1.04, -0.68, 0.78][index];
-  const tiltZ = [0.16, -0.3, 0.52, -0.62][index];
+  const radius = [1.72, 1.88, 2.04, 2.2, 2.36][index];
+  const tiltX = [0.4, 1.04, -0.68, 0.78, -1.02][index];
+  const tiltZ = [0.16, -0.3, 0.52, -0.62, 0.34][index];
   const points = [];
   for (let point = 0; point <= 256; point += 1) {
     const angle = (point / 256) * Math.PI * 2;
@@ -1162,7 +1166,10 @@ async function initScene() {
   renderer.setPixelRatio(
     Math.min(window.devicePixelRatio, window.innerWidth <= 760 ? 1.15 : 1.5),
   );
-  renderer.setSize(window.innerWidth, window.innerHeight);
+  const canvasBounds = el.canvas.getBoundingClientRect();
+  const canvasWidth = Math.max(1, Math.round(canvasBounds.width));
+  const canvasHeight = Math.max(1, Math.round(canvasBounds.height));
+  renderer.setSize(canvasWidth, canvasHeight, false);
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.28;
@@ -1170,7 +1177,7 @@ async function initScene() {
 
   scene = new THREE.Scene();
   scene.fog = new THREE.FogExp2(0x020607, 0.022);
-  camera = new THREE.PerspectiveCamera(42, window.innerWidth / window.innerHeight, 0.1, 100);
+  camera = new THREE.PerspectiveCamera(42, canvasWidth / canvasHeight, 0.1, 100);
   camera.position.set(0, 0, state.zoom);
 
   createStars();
@@ -1184,6 +1191,10 @@ async function initScene() {
     showToast("Earth textures could not load; verification remains available.");
   }
   bindGlobeInput();
+  if ("ResizeObserver" in window) {
+    sceneResizeObserver = new ResizeObserver(scheduleSceneResize);
+    sceneResizeObserver.observe(el.canvas);
+  }
   selectMode(state.mode, false);
   selectCity(state.activeCity, false);
   setBootProgress(90);
@@ -1377,13 +1388,31 @@ function animate(time = 0) {
 
 function resize() {
   if (!renderer || !camera) return;
+  const bounds = el.canvas.getBoundingClientRect();
+  const width = Math.max(1, Math.round(bounds.width));
+  const height = Math.max(1, Math.round(bounds.height));
   renderer.setPixelRatio(
     Math.min(window.devicePixelRatio, window.innerWidth <= 760 ? 1.15 : 1.5),
   );
-  renderer.setSize(window.innerWidth, window.innerHeight);
-  camera.aspect = window.innerWidth / window.innerHeight;
+  renderer.setSize(width, height, false);
+  camera.aspect = width / height;
   camera.fov = window.innerWidth <= 760 ? 50 : 42;
   camera.updateProjectionMatrix();
+}
+
+function scheduleSceneResize() {
+  window.cancelAnimationFrame(sceneResizeFrame);
+  sceneResizeFrame = window.requestAnimationFrame(resize);
+}
+
+function setLuminousExpanded(expanded) {
+  state.luminousExpanded = Boolean(expanded);
+  document.body.classList.toggle("luminous-expanded", state.luminousExpanded);
+  el.luminousToggle.setAttribute("aria-expanded", String(state.luminousExpanded));
+  const action = state.luminousExpanded ? "Collapse" : "Expand";
+  el.luminousToggle.setAttribute("aria-label", `${action} proof explorer`);
+  el.luminousToggle.title = `${action} proof explorer`;
+  scheduleSceneResize();
 }
 
 function updateOrbitSelection() {
@@ -1429,6 +1458,7 @@ function selectMode(name, withTone = true) {
   state.mode = name;
   state.lastResult = null;
   document.body.classList.toggle("luminous-mode", name === "rootprint");
+  scheduleSceneResize();
   const mode = modes[name];
   document.documentElement.style.setProperty(
     "--mode-color",
@@ -2518,6 +2548,12 @@ function bindInterface() {
   el.observatoryClose.addEventListener("click", () =>
     document.body.classList.remove("observatory-open"),
   );
+  el.luminousToggle.addEventListener("click", () =>
+    setLuminousExpanded(!state.luminousExpanded),
+  );
+  el.luminousExplorer.addEventListener("transitionend", (event) => {
+    if (event.propertyName === "height") resize();
+  });
   el.evaluationToggle.addEventListener("click", () => {
     document.body.classList.remove("observatory-open");
     document.body.classList.add("evaluation-open");

--- a/publicpower/index.html
+++ b/publicpower/index.html
@@ -310,8 +310,11 @@
           <div><dt>SIDECAR</dt><dd id="luminous-sidecar-state">AWAITING</dd></div>
           <div><dt>PACKETS</dt><dd id="luminous-packet-count">0 / 4</dd></div>
         </dl>
+        <button id="luminous-toggle" class="luminous-toggle" type="button" aria-expanded="false" aria-controls="luminous-workspace" aria-label="Expand proof explorer" title="Expand proof explorer">
+          <span data-icon="chevron-right"></span>
+        </button>
       </header>
-      <div class="luminous-workspace">
+      <div id="luminous-workspace" class="luminous-workspace">
         <div class="luminous-map">
           <div class="luminous-map-label">
             <span>ROOTPRINT DAG</span>


### PR DESCRIPTION
## What changed

- render the WebGL globe inside the unobstructed instrument viewport instead of behind the verifier dock
- collapse the semantic Rootprint explorer to a compact status strip by default, with an accessible expand/collapse control
- resize the renderer and camera when panels, breakpoints, or viewport dimensions change
- restore zoom-out on mobile and remove fixed minimum viewport heights
- add the missing fifth orbital geometry configuration so the Committed proof orbit contains finite coordinates

## Root cause

The Rootprint explorer permanently occupied 238px above the 166px verifier dock while the globe still rendered against the full browser window. On common displays this covered more than half of the interactive scene. The orbital configuration also had only four geometry entries for five proof modes, producing NaN coordinates for the Committed orbit.

## Validation

- responsive geometry and interaction checks at 1440x900, 1280x720, 1024x768, 390x844, and 360x640
- collapsed and expanded explorer transitions verified
- desktop, tablet, and mobile world-observatory drawers verified within viewport bounds
- mobile zoom-in, zoom-out, and reset controls exercised
- WebGL initialized without geometry or JavaScript errors
- Rootprint, Sextillion, Hyperscale, Megaround, and Committed browser verification paths all reached `VERIFICATION COMPLETE`
- `node --check publicpower/app.js`
- `git diff --check`